### PR TITLE
Added unit tests to word_count that are in C#

### DIFF
--- a/word-count/example.cpp
+++ b/word-count/example.cpp
@@ -1,6 +1,12 @@
+#if defined(_MSC_VER) && _MSC_VER >= 1400 
+#pragma warning(push) 
+#pragma warning(disable:4996) 
+#endif 
+
 #include "word_count.h"
-#include <boost/algorithm/string/case_conv.hpp>
-#include <boost/tokenizer.hpp>
+#include <vector>
+#include <locale>
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 
@@ -9,11 +15,27 @@ namespace word_count
 
 map<string, int> words(string const& text)
 {
-    map<string, int> counts;
-    for (auto const& word : boost::tokenizer<>(text)) {
-        counts[boost::to_lower_copy(word)]++;
+    // A less than ideal solution since I can't get regex building in GCC on Travis
+    std::map<std::string, int> count;
+    std::string normalized = boost::to_lower_copy( text );
+    for ( unsigned int i = 0; i < normalized.length(); i++ )
+    {
+        auto c = normalized[i];
+        normalized[i] = ( std::isalnum( c, std::locale() ) || c == '\'' ) ? c : ' ';
     }
-    return counts;
+    std::vector<std::string> words;
+    boost::split( words, normalized, boost::is_any_of( "\t " ) );
+    for ( auto const& word : words )
+    {
+        auto const& trimmed = boost::trim_copy_if( word, boost::is_any_of( "' " ) );
+        if ( !trimmed.empty() )
+            count[trimmed]++;
+    }
+    return count;
 }
 
 }
+
+#if defined(_MSC_VER) && _MSC_VER >= 1400 
+#pragma warning(pop) 
+#endif 

--- a/word-count/word_count_test.cpp
+++ b/word-count/word_count_test.cpp
@@ -93,4 +93,44 @@ BOOST_AUTO_TEST_CASE(counts_multiline)
 
     REQUIRE_EQUAL_CONTAINERS(expected, actual);
 }
+
+BOOST_AUTO_TEST_CASE(count_everything_just_once)
+{
+    const map<string, int> expected{{"all", 2}, {"the", 2}, {"kings", 2}, {"horses", 1}, {"and", 1}, {"men", 1}};
+    const auto actual = word_count::words( "all the kings horses and all the kings men");
+    
+    REQUIRE_EQUAL_CONTAINERS( expected, actual );
+}
+
+BOOST_AUTO_TEST_CASE(handles_cramped_list)
+{
+    const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
+    const auto actual = word_count::words( "one,two,three" );
+
+    REQUIRE_EQUAL_CONTAINERS( expected, actual );
+}
+
+BOOST_AUTO_TEST_CASE(with_apostrophes)
+{
+    const map<string, int> expected{{"first", 1}, {"don't", 2}, {"laugh", 1}, {"then", 1}, {"cry", 1}};
+    const auto actual = word_count::words( "First: don't laugh. Then: don't cry." );
+
+    REQUIRE_EQUAL_CONTAINERS( expected, actual );
+}
+
+BOOST_AUTO_TEST_CASE(with_free_standing_apostrophes)
+{
+    const map<string, int> expected{{ "go", 3 }};
+    const auto actual = word_count::words( "go ' Go '' GO" );
+
+    REQUIRE_EQUAL_CONTAINERS( expected, actual );
+}
+
+BOOST_AUTO_TEST_CASE(with_apostrophes_as_quotes)
+{
+    const map<string, int> expected{{"she", 1}, {"said", 1}, {"let's", 1}, {"meet", 1}, {"at", 1}, {"twelve", 1}, {"o'clock", 1}};
+    const auto actual = word_count::words( "She said, 'let's meet at twelve o'clock'" );
+
+    REQUIRE_EQUAL_CONTAINERS( expected, actual );
+}
 #endif


### PR DESCRIPTION
This version of the C++ exercise was much simpler to solve than the C# version because it had very few tests for boundary conditions. I have converted the C# tests and updated the example code so that the new tests pass. 
