### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xC++
+# C++
 
-[![Travis Build Status](https://api.travis-ci.org/exercism/xcpp.svg?branch=master)](https://travis-ci.org/exercism/xcpp)
+[![Travis Build Status](https://api.travis-ci.org/exercism/cpp.svg?branch=master)](https://travis-ci.org/exercism/cpp)
 
 Exercism Exercises in C++
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "cpp",
   "language": "C++",
-  "repository": "https://github.com/exercism/xcpp",
+  "repository": "https://github.com/exercism/cpp",
   "active": true,
   "deprecated": [
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -78,7 +78,7 @@ not worry about setting up a build for each exercise.
 
 Getting a portable build isn't easy and requires access to many kinds of
 systems.  If you encounter any problems with the supplied CMake recipe,
-please [report the issue](https://github.com/exercism/xcpp/issues) so we can
+please [report the issue](https://github.com/exercism/cpp/issues) so we can
 improve the CMake support.
 
 [CMake 2.8.11 or later](http://www.cmake.org/) is required to use the provided build recipe.
@@ -96,7 +96,7 @@ boost libraries Boost.Test, Boost.DateTime and Boost.Regex, or you will
 need to download from source and build the library yourself.
 
 If you are having difficulties installing Boost for use with exercism,
-[ask for help](https://github.com/exercism/xcpp/issues).
+[ask for help](https://github.com/exercism/cpp/issues).
 
 #### Linux
 


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1