### PR TITLE
[WIP] Improve robot-name tests.

### DIFF
--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,20 +1,22 @@
 #include "robot_name.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/regex.hpp>
+#include <regex>
+#include <string>
+#include <unordered_set>
 
 using namespace std;
 
 namespace
 {
-const boost::regex name_pattern{R"name(^[[:upper:]]{2}\d{3}$)name"};
+const regex name_pattern("[A-Z]{2}[0-9]{3}");
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)
 {
     const robot_name::robot robot;
 
-    BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+    BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -46,12 +48,14 @@ BOOST_AUTO_TEST_CASE(is_able_to_reset_name)
 BOOST_AUTO_TEST_CASE(exhausting_digits_yields_different_names)
 {
     robot_name::robot robot;
-    auto last_name = robot.name();
+    unordered_set<string> names;
+    names.insert(robot.name());
 
     for (int i = 0; i < 1000; ++i) {
         robot.reset();
-        BOOST_REQUIRE_NE(last_name, robot.name());
-        BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+        BOOST_REQUIRE_EQUAL(names.count(robot.name()), 0);
+        BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
+        names.insert(robot.name());
     }
 }
 #endif


### PR DESCRIPTION
Improves the tests for robot-name (making sure that it can generate at least 1000 unique robot names), and transition to regex from the std library instead of Boost.

*This may break in Travis, as there were supposedly some issues with the regex implementation in old versions of the stdlib. Currently this is a WIP to test against that passing.

I will update this PR to remove boost regex as a dependency for all the tests if there are no issues.
