### PR TITLE
Port atbash-cipher exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach(exercise
     meetup
     queen-attack
     allergies
+    atbash-cipher
 )
     set(exercise_dir exercises/${exercise})
     travis_fixup(${exercise})

--- a/config.json
+++ b/config.json
@@ -298,6 +298,14 @@
         "bitwise operations",
         "filtering"
       ]
+    },
+    {
+      "difficulty": 3,
+      "slug": "atbash-cipher",
+      "topics": [
+        "strings",
+        "algorithms"
+      ]
     }
   ]
 }

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Get the exercise name from the current directory
+get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+
+# Basic CMake project
+cmake_minimum_required(VERSION 2.8.11)
+
+# Name the project after the exercise
+project(${exercise} CXX)
+
+# Locate Boost libraries: unit_test_framework, date_time and regex
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+
+# Enable C++11 features on gcc/clang
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set(CMAKE_CXX_FLAGS "-std=c++11")
+endif()
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
+endif()
+
+# Get a source filename from the exercise name by replacing -'s with _'s
+string(REPLACE "-" "_" file ${exercise})
+
+# Implementation could be only a header
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${file}.cpp)
+    set(exercise_cpp ${file}.cpp)
+else()
+    set(exercise_cpp "")
+endif()
+
+# Build executable from sources and headers
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+# We need boost includes
+target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
+
+# We need boost libraries
+target_link_libraries(${exercise} ${Boost_LIBRARIES})
+
+# Tell MSVC not to warn us about unchecked iterators in debug builds
+if(${MSVC})
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+endif()
+
+# Run the tests on every build
+add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})

--- a/exercises/atbash-cipher/atbash_cipher_test.cpp
+++ b/exercises/atbash-cipher/atbash_cipher_test.cpp
@@ -1,0 +1,68 @@
+#include "atbash_cipher.h"
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(encode_yes)
+{
+    BOOST_REQUIRE_EQUAL("bvh", atbash::encode("yes"));
+}
+
+#if defined(EXERCISM_RUN_ALL_TESTS)
+BOOST_AUTO_TEST_CASE(encode_no)
+{
+    BOOST_REQUIRE_EQUAL("ml", atbash::encode("no"));
+}
+
+BOOST_AUTO_TEST_CASE(encode_OMG)
+{
+    BOOST_REQUIRE_EQUAL("lnt", atbash::encode("OMG"));
+}
+
+BOOST_AUTO_TEST_CASE(encode_spaces)
+{
+    BOOST_REQUIRE_EQUAL("lnt", atbash::encode("O M G"));
+}
+
+BOOST_AUTO_TEST_CASE(encode_mindblowingly)
+{
+    BOOST_REQUIRE_EQUAL("nrmwy oldrm tob", atbash::encode("mindblowingly"));
+}
+
+BOOST_AUTO_TEST_CASE(encode_numbers)
+{
+    BOOST_REQUIRE_EQUAL("gvhgr mt123 gvhgr mt", atbash::encode("Testing,1 2 3, testing."));
+}
+
+BOOST_AUTO_TEST_CASE(encode_deep_thought)
+{
+    BOOST_REQUIRE_EQUAL("gifgs rhurx grlm", atbash::encode("Truth is fiction."));
+}
+
+BOOST_AUTO_TEST_CASE(encode_all_the_letters)
+{
+    BOOST_REQUIRE_EQUAL("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
+                        atbash::encode("The quick brown fox jumps over the lazy dog."));
+}
+
+BOOST_AUTO_TEST_CASE(decode_exercism)
+{
+    BOOST_REQUIRE_EQUAL("exercism", atbash::decode("vcvix rhn"));
+}
+
+BOOST_AUTO_TEST_CASE(decode_a_sentence)
+{
+    BOOST_REQUIRE_EQUAL("anobstacleisoftenasteppingstone",
+                        atbash::decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"));
+}
+
+BOOST_AUTO_TEST_CASE(decode_numbers)
+{
+    BOOST_REQUIRE_EQUAL("testing123testing", atbash::decode("gvhgr mt123 gvhgr mt"));
+}
+
+BOOST_AUTO_TEST_CASE(decode_all_the_letters)
+{
+    BOOST_REQUIRE_EQUAL("thequickbrownfoxjumpsoverthelazydog",
+                        atbash::decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"));
+}
+#endif

--- a/exercises/atbash-cipher/example.cpp
+++ b/exercises/atbash-cipher/example.cpp
@@ -1,0 +1,54 @@
+#include <sstream>
+#include <string>
+
+#include "atbash_cipher.h"
+
+namespace atbash {
+
+const char ALPHA_START = 'a';
+const char ALPHA_END = 'z';
+
+char atbash_transform(char c)
+{
+    return std::isalpha(c) ? ALPHA_END - std::tolower(c) + ALPHA_START : c;
+}
+
+std::string encode(std::string const& plaintext)
+{            
+    int chunkSize = 5;
+    int chunkCounter = 0;
+    std::ostringstream os;
+
+    for(int i = 0; i < plaintext.length(); i++) {
+        char currentChar = plaintext.at(i);
+
+        if (std::isalnum(currentChar)) {
+            if ((chunkCounter > 0) && ((chunkCounter) % chunkSize == 0)) {
+                os << " ";
+            }
+            
+            os << atbash_transform(currentChar);
+            chunkCounter++;
+        }
+    }
+
+    return os.str();
+}
+
+std::string decode(std::string const& ciphertext)
+{
+    std::ostringstream os;
+
+    for(int i = 0; i < ciphertext.length(); i++) {
+        char currentChar = ciphertext.at(i);
+
+        if (std::isalnum(currentChar)) {
+            os << atbash_transform(currentChar);
+        }
+    }
+
+    return os.str();
+}
+
+}
+

--- a/exercises/atbash-cipher/example.h
+++ b/exercises/atbash-cipher/example.h
@@ -1,0 +1,13 @@
+#if !defined(ATBASH_CIPHER_H)
+#define ATBASH_CIPHER_H
+
+#include <string>
+
+namespace atbash
+{
+
+std::string encode(std::string const& plaintext);
+std::string decode(std::string const& ciphertext);
+
+}
+#endif


### PR DESCRIPTION
Here's a port of the atbash-cipher exercise. Was originally gonna do the example implementation with some tidy modern c++ std::erase_if and std::transform stuff until I realized it'd take 3 passes over the string, yuck. So, for-loops in 1 pass it is. Let me know if anything needs changed.