### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,47 +3,59 @@
   "language": "C++",
   "repository": "https://github.com/exercism/cpp",
   "active": true,
-  "deprecated": [
-
-  ],
   "foregone": [
     "point-mutations"
   ],
   "exercises": [
     {
-      "difficulty": 1,
+      "uuid": "3eeadff6-82b6-43be-8834-d9ef258e454d",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "strings"
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "76a840c7-24f1-455d-b62e-da42b13f8dd5",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "logic",
         "control-flow (conditionals)"
       ]
     },
     {
-      "difficulty": 2,
+      "uuid": "4dbe1bb3-0419-4749-8c2a-ec91539a8640",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
         "dates",
         "interfaces"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "a9716747-8cc6-4529-b5d2-dc24bd8641a8",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "control-flow (loops)"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "d80210b8-45e8-4e5c-8b07-9e87c33c5959",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "control-flow (conditionals)",
@@ -51,8 +63,11 @@
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "a34d1c83-fb96-4b7a-aeca-fdb17cf91a75",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "filtering",
@@ -60,8 +75,11 @@
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "0dd45f6a-c6cd-4549-a56b-7babe0a71add",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "maps",
         "arrays",
@@ -69,8 +87,11 @@
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "d531e2b1-28bc-4025-b3a7-119d314b5a80",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "arrays",
@@ -79,23 +100,32 @@
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "46cb230c-8ce9-431d-9dea-a195a3abd117",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "control-flow (loops)"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "949f5680-a7a5-4c1e-ac19-bb4bae658d5c",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "parsing"
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "6805ef10-ab91-4d97-af80-9d326255497d",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
         "strings",
         "control-flow (loops)",
@@ -103,108 +133,150 @@
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "76491cb2-25a8-4495-ba3e-85aace65319e",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "parsing"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "a15922b1-467f-4db4-a023-0bb262333551",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "arrays",
         "parsing"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "67c3cb10-b893-428a-82d0-79602aef2775",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "randomness"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "a190ad11-db1c-4624-a477-e1d0c91d8b4f",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "mathematics"
       ]
     },
     {
-      "difficulty": 1,
+      "uuid": "1763159f-3358-42d0-9ad0-2eb90baca600",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
         "functions"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "e597f659-f31a-4a1b-a697-d91ede672642",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "interfaces",
         "functions"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "54a0753e-c161-4dfd-a7b0-02dc7a923d82",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "maps"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "d23a2c36-7182-4fd0-84db-34b27fabda2e",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "mathematics",
         "control-flow (conditionals)"
       ]
     },
     {
-      "difficulty": 2,
+      "uuid": "c3dc3764-72b9-4926-9747-61db90553e2b",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
         "bitwise operations"
       ]
     },
     {
-      "difficulty": 2,
+      "uuid": "9155f4ea-3566-4a57-a2c5-76535d931ccc",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
         "strings"
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "52dce31c-f8ab-44db-accd-573f4b82dcf9",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
         "strings",
         "mathematics"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "1cc6a583-3def-4d15-a45a-4b1fe16826bf",
       "slug": "binary",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "mathematics"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "ba755932-b301-41cc-b7f2-5e6d2e130325",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "mathematics",
         "control-flow (loops)"
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "177ecdf4-f249-4193-b9e1-8f1c6480bfad",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
         "strings",
         "filtering",
@@ -212,23 +284,32 @@
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "c8246de0-29b1-4f92-8b00-b766e395ad66",
       "slug": "trinary",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "mathematics"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "2fbd008c-5007-4403-ae71-f4d1f5ccaf8f",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings"
       ]
     },
     {
-      "difficulty": 10,
+      "uuid": "090b2615-cd05-442b-be74-9f11bd5a83a5",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 10,
       "topics": [
         "strings",
         "logic",
@@ -236,16 +317,22 @@
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "7ea05dd1-2c3c-499e-8608-dc76d30c5457",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "mathematics",
         "control-flow (loops)"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "0ab70460-3a2f-4c37-bb78-716ba720fe34",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "strings",
         "arrays",
@@ -253,47 +340,65 @@
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "fab94f5a-d4da-4a18-a70a-b27c80b14851",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "classes",
         "time"
       ]
     },
     {
-      "difficulty": 7,
+      "uuid": "a384c32c-d8db-4877-816b-44de7c3ed324",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
         "strings",
         "text formatting"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "675b0a5c-0587-4dc5-8004-1f82769a2ddd",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "mathematics"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "c2e8e3fc-a39c-434b-87dd-9524636aa804",
       "slug": "hexadecimal",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "strings",
         "mathematics"
       ]
     },
     {
-      "difficulty": 5,
+      "uuid": "0d5e4c9e-4351-41b1-9154-ee900ad0e60e",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
         "logic",
         "control-flow (loops)"
       ]
     },
     {
-      "difficulty": 3,
+      "uuid": "80ae6a8e-8464-4f3a-afed-14d424757413",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
         "bitwise operations",
         "filtering"


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16