### PR TITLE
Generate static exercise README templates

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -1,0 +1,16 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -1,0 +1,69 @@
+# Allergies
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
+
+The list of items (and their value) that were tested are:
+
+* eggs (1)
+* peanuts (2)
+* shellfish (4)
+* strawberries (8)
+* tomatoes (16)
+* chocolate (32)
+* pollen (64)
+* cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.
+allergens that score 256, 512, 1024, etc.).  Your program should
+ignore those components of the score.  For example, if the allergy
+score is 257, your program should only report the eggs (1) allergy.
+
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,0 +1,45 @@
+# Anagram
+
+Given a word and a list of possible anagrams, select the correct sublist.
+
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -1,0 +1,66 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,0 +1,359 @@
+# Beer Song
+
+Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+
+Note that not all verses are identical.
+
+```plain
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 6 bottles of beer on the wall.
+
+6 bottles of beer on the wall, 6 bottles of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+```
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+* Remove as much duplication as you possibly can.
+* Optimize for readability, even if it means introducing duplication.
+* If you've removed all the duplication, do you have a lot of
+  conditionals? Try replacing the conditionals with polymorphism, if it
+  applies in this language. How readable is it?
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -1,0 +1,67 @@
+# Binary
+
+Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
+
+Implement binary to decimal conversion. Given a binary input
+string, your program should produce a decimal output. The
+program should handle invalid inputs.
+
+## Note
+- Implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About Binary (Base-2)
+Decimal is a base-10 system.
+
+A number 23 in base 10 notation can be understood
+as a linear combination of powers of 10:
+
+- The rightmost digit gets multiplied by 10^0 = 1
+- The next number gets multiplied by 10^1 = 10
+- ...
+- The *n*th number gets multiplied by 10^*(n-1)*.
+- All these values are summed.
+
+So: `23 => 2*10^1 + 3*10^0 => 2*10 + 3*1 = 23 base 10`
+
+Binary is similar, but uses powers of 2 rather than powers of 10.
+
+So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,50 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,0 +1,45 @@
+# Clock
+
+Implement a clock that handles times without dates.
+
+You should be able to add and subtract minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,0 +1,106 @@
+# Crypto Square
+
+Implement the classic method for composing secret messages called a square code.
+
+Given an English text, output the encoded version of that text.
+
+First, the input is normalized: the spaces and punctuation are removed
+from the English text and the message is downcased.
+
+Then, the normalized characters are broken into rows.  These rows can be
+regarded as forming a rectangle when printed with intervening newlines.
+
+For example, the sentence
+
+> If man was meant to stay on the ground, god would have given us roots.
+
+is normalized to:
+
+> ifmanwasmeanttostayonthegroundgodwouldhavegivenusroots
+
+The plaintext should be organized in to a rectangle.  The size of the
+rectangle (`r x c`) should be decided by the length of the message,
+such that `c >= r` and `c - r <= 1`, where `c` is the number of columns
+and `r` is the number of rows.
+
+Our normalized text is 54 characters long, dictating a rectangle with
+`c = 8` and `r = 7`:
+
+```plain
+ifmanwas
+meanttos
+tayonthe
+groundgo
+dwouldha
+vegivenu
+sroots
+```
+
+The coded message is obtained by reading down the columns going left to
+right.
+
+The message above is coded as:
+
+```plain
+imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau
+```
+
+Output the encoded text in chunks.  Phrases that fill perfect squares
+`(r X r)` should be output in `r`-length chunks separated by spaces.
+Imperfect squares will have `n` empty spaces.  Those spaces should be distributed evenly across the last `n` rows.
+
+```plain
+imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau
+```
+
+Notice that were we to stack these, we could visually decode the
+cyphertext back in to the original message:
+
+```plain
+imtgdvs
+fearwer
+mayoogo
+anouuio
+ntnnlvt
+wttddes
+aohghn
+sseoau
+```
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,51 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,83 @@
+# Etl
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -1,0 +1,102 @@
+# Food Chain
+
+Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'.
+
+While you could copy/paste the lyrics,
+or read them from a file, this problem is much more
+interesting if you approach it algorithmically.
+
+This is a [cumulative song](http://en.wikipedia.org/wiki/Cumulative_song) of unknown origin.
+
+This is one of many common variants.
+
+```plain
+I know an old lady who swallowed a fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a spider.
+It wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a bird.
+How absurd to swallow a bird!
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cat.
+Imagine that, to swallow a cat!
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a dog.
+What a hog, to swallow a dog!
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a goat.
+Just opened her throat and swallowed a goat!
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a cow.
+I don't know how she swallowed a cow!
+She swallowed the cow to catch the goat.
+She swallowed the goat to catch the dog.
+She swallowed the dog to catch the cat.
+She swallowed the cat to catch the bird.
+She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.
+She swallowed the spider to catch the fly.
+I don't know why she swallowed the fly. Perhaps she'll die.
+
+I know an old lady who swallowed a horse.
+She's dead, of course!
+```
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly](http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,43 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -1,0 +1,74 @@
+# Grade School
+
+Given students' names along with the grade that they are in, create a roster
+for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.  Grades should sort
+  as 1, 2, 3, etc., and students within a grade should be sorted
+  alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
+    Grade 3…"
+
+Note that all our students only have one name.  (It's a small town, what
+do you want?)
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- If you're working in a language with mutable data structures and your
+  implementation allows outside code to mutate the school's internal DB
+  directly, see if you can prevent this. Feel free to introduce additional
+  tests.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,0 +1,66 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board. Two grains on
+the next. Four on the third, and so on.
+
+There are 64 squares on a chessboard.
+
+Write code that shows:
+- how many grains were on each square, and
+- the total number of grains
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,74 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,53 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -1,0 +1,46 @@
+# Hexadecimal
+
+Convert a hexadecimal number, represented as a string (e.g. "10af8c"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).
+
+On the web we use hexadecimal to represent colors, e.g. green: 008000,
+teal: 008080, navy: 000080).
+
+The program should handle invalid hexadecimal strings.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/examples/NumberBases.html](http://www.wolframalpha.com/examples/NumberBases.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,65 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```plain
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -1,0 +1,62 @@
+# Meetup
+
+Calculate the date of meetups.
+
+Typically meetups happen on the same day of the week.  In this exercise, you will take
+a description of a meetup date, and return the actual meetup date.
+
+Examples of general descriptions are:
+
+- the first Monday of January 2017
+- the third Tuesday of January 2017
+- the Wednesteenth of January 2017
+- the last Thursday of January 2017
+
+Note that "Monteenth", "Tuesteenth", etc are all made up words. There
+was a meetup whose members realized that there are exactly 7 numbered days in a month that
+end in '-teenth'. Therefore, one is guaranteed that each day of the week
+(Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
+in every month.
+
+Given examples of a meetup dates, each containing a month, day, year, and descriptor 
+(first, second, teenth, etc), calculate the date of the actual meetup.
+For example, if given "First Monday of January 2017", the correct meetup date is 2017/1/2
+ 
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -1,0 +1,47 @@
+# Nth Prime
+
+Given a number n, determine what the nth prime is.
+
+By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that
+the 6th prime is 13.
+
+If your language provides methods in the standard library to deal with prime
+numbers, pretend they don't exist and implement them yourself.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A variation on Problem 7 at Project Euler [http://projecteuler.net/problem=7](http://projecteuler.net/problem=7)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,65 @@
+# Nucleotide Count
+
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
+DNA is represented by an alphabet of the following symbols: 'A', 'C',
+'G', and 'T'.
+
+Each symbol represents a nucleotide, which is a fancy name for the
+particular molecules that happen to make up a large part of DNA.
+
+Shortest intro to biochemistry EVAR:
+
+- twigs are to birds nests as
+- nucleotides are to DNA and RNA as
+- amino acids are to proteins as
+- sugar is to starch as
+- oh crap lipids
+
+I'm not going to talk about lipids because they're crazy complex.
+
+So back to nucleotides.
+
+DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
+(`G`), and thymine (`T`).
+
+RNA contains a slightly different set of nucleotides, but we don't care
+about that for now.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,66 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+
+The format is usually represented as
+```
+(NXX)-NXX-XXXX
+```
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -1,0 +1,68 @@
+# Prime Factors
+
+Compute the prime factors of a given natural number.
+
+A prime number is only evenly divisible by itself and 1.
+
+Note that 1 is not a prime number.
+
+## Example
+
+What are the prime factors of 60?
+
+- Our first divisor is 2. 2 goes into 60, leaving 30.
+- 2 goes into 30, leaving 15.
+  - 2 doesn't go cleanly into 15. So let's move on to our next divisor, 3.
+- 3 goes cleanly into 15, leaving 5.
+  - 3 does not go cleanly into 5. The next possible factor is 4.
+  - 4 does not go cleanly into 5. The next possible factor is 5.
+- 5 does go cleanly into 5.
+- We're left only with 1, so now, we're done.
+
+Our successful divisors in that computation represent the list of prime
+factors of 60: 2, 2, 3, and 5.
+
+You can check this yourself:
+
+- 2 * 2 * 3 * 5
+- = 4 * 15
+- = 60
+- Success!
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Prime Factors Kata by Uncle Bob [http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata](http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -1,0 +1,65 @@
+# Queen Attack
+
+Given the position of two queens on a chess board, indicate whether or not they
+are positioned so that they can attack each other.
+
+In the game of chess, a queen can attack pieces which are on the same
+row, column, or diagonal.
+
+A chessboard can be represented by an 8 by 8 array.
+
+So if you're told the white queen is at (2, 3) and the black queen at
+(5, 6), then you'd know you've got a set-up like so:
+
+```plain
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ W _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ B _
+_ _ _ _ _ _ _ _
+_ _ _ _ _ _ _ _
+```
+
+You'd also be able to answer whether the queens can attack each other.
+In this case, that answer would be yes, they can, because both pieces
+share a diagonal.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,0 +1,56 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,57 @@
+# Rna Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -1,0 +1,54 @@
+# Robot Name
+
+Manage robot factory settings.
+
+When robots come off the factory floor, they have no name.
+
+The first time you boot them up, a random name is generated in the format
+of two uppercase letters followed by three digits, such as RX837 or BC811.
+
+Every once in a while we need to reset a robot to its factory settings,
+which means that their name gets wiped. The next time you ask, it will
+respond with a new random name.
+
+The names must be random: they should not follow a predictable sequence.
+Random names means a risk of collisions. Your solution must ensure that
+every existing robot has a unique name.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A debugging session with Paul Blackwell at gSchool. [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,81 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,0 +1,101 @@
+# Say
+
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
+## Step 1
+
+Handle the basic case of 0 through 99.
+
+If the input to the program is `22`, then the output should be
+`'twenty-two'`.
+
+Your program should complain loudly if given a number outside the
+blessed range.
+
+Some good test cases for this program are:
+
+- 0
+- 14
+- 50
+- 98
+- -1
+- 100
+
+### Extension
+
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out
+loud.
+
+## Step 2
+
+Implement breaking a number up into chunks of thousands.
+
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the
+far simpler `1000` should yield just 1 and 0.
+
+The program must also report any values that are out of range.
+
+## Step 3
+
+Now handle inserting the appropriate scale word between those chunks.
+
+So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
+
+The program must also report any values that are out of range.  It's
+fine to stop at "trillion".
+
+## Step 4
+
+Put it all together to get nothing but plain English.
+
+`12345` should give `twelve thousand three hundred forty-five`.
+
+The program must also report any values that are out of range.
+
+### Extensions
+
+Use _and_ (correctly) when spelling out the number in English:
+
+- 14 becomes "fourteen".
+- 100 becomes "one hundred".
+- 120 becomes "one hundred and twenty".
+- 1002 becomes "one thousand and two".
+- 1323 becomes "one thousand three hundred and twenty-three".
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,0 +1,76 @@
+# Scrabble Score
+
+Given a word, compute the scrabble score for that word.
+
+## Letter Values
+
+You'll need these:
+
+```plain
+Letter                           Value
+A, E, I, O, U, L, N, R, S, T       1
+D, G                               2
+B, C, M, P                         3
+F, H, V, W, Y                      4
+K                                  5
+J, X                               8
+Q, Z                               10
+```
+
+## Examples
+"cabbage" should be scored as worth 14 points:
+
+- 3 points for C
+- 1 point for A, twice
+- 3 points for B, twice
+- 2 points for G
+- 1 point for E
+
+And to total:
+
+- `3 + 2*1 + 2*3 + 2 + 1`
+- = `3 + 2 + 6 + 3`
+- = `5 + 9`
+- = 14
+
+## Extensions
+- You can play a double or a triple letter.
+- You can play a double or a triple word.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,59 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -1,0 +1,66 @@
+# Sieve
+
+Use the Sieve of Eratosthenes to find all the primes from 2 up to a given
+number.
+
+The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
+prime numbers up to any given limit. It does so by iteratively marking as
+composite (i.e. not prime) the multiples of each prime,
+starting with the multiples of 2.
+
+Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
+
+The algorithm consists of repeating the following over and over:
+
+- take the next available unmarked number in your list (it is prime)
+- mark all the multiples of that number (they are not prime)
+
+Repeat until you have processed each number in your range.
+
+When the algorithm terminates, all the numbers in the list that have not
+been marked are prime.
+
+The wikipedia article has a useful graphic that explains the algorithm:
+https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
+
+Notice that this is a very specific algorithm, and the tests don't check
+that you've implemented the algorithm, only that you've come up with the
+correct list of primes.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Sieve of Eratosthenes at Wikipedia [http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes](http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,0 +1,56 @@
+# Space Age
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,0 +1,50 @@
+# Sum Of Multiples
+
+Given a number, find the sum of all the multiples of particular numbers up to
+but not including that number.
+
+If we list all the natural numbers up to but not including 20 that are
+multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+Given a number, find the sum of the multiples of a given set of numbers,
+up to but not including that number.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,58 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -1,0 +1,60 @@
+# Trinary
+
+Convert a trinary number, represented as a string (e.g. '102012'), to its
+decimal equivalent using first principles.
+
+The program should consider strings specifying an invalid trinary as the
+value 0.
+
+Trinary numbers contain three symbols: 0, 1, and 2.
+
+The last place in a trinary number is the 1's place. The second to last
+is the 3's place, the third to last is the 9's place, etc.
+
+```bash
+# "102012"
+    1       0       2       0       1       2    # the number
+1*3^5 + 0*3^4 + 2*3^3 + 0*3^2 + 1*3^1 + 2*3^0    # the value
+  243 +     0 +    54 +     0 +     3 +     2 =  302
+```
+
+If your language provides a method in the standard library to perform the
+conversion, pretend it doesn't exist and implement it yourself.
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+All of Computer Science [http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-](http://www.wolframalpha.com/input/?i=binary&a=*C.binary-_*MathWorld-)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,0 +1,51 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```plain
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+
+## Getting Started
+
+Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
+exercism.io.  This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Passing the Tests
+
+Get the first test compiling, linking and passing by following the [three
+rules of test-driven development](http://butunclebob.com/ArticleS.UncleBob.TheThreeRulesOfTdd).
+Create just enough structure by declaring namespaces, functions, classes,
+etc., to satisfy any compiler errors and get the test to fail.  Then write
+just enough code to get the test to pass.  Once you've done that,
+uncomment the next test by moving the following line past the next test.
+
+```C++
+#if defined(EXERCISM_RUN_ALL_TESTS)
+```
+
+This may result in compile errors as new constructs may be invoked that
+you haven't yet declared or defined.  Again, fix the compile errors minimally
+to get a failing test, then change the code minimally to pass the test,
+refactor your implementation for readability and expressiveness and then
+go on to the next test.
+
+Try to use standard C++11 facilities in preference to writing your own
+low-level algorithms or facilities by hand.  [CppReference](http://en.cppreference.com/)
+is a wiki reference to the C++ language and standard library.  If you
+are new to C++, but have programmed in C, beware of
+[C traps and pitfalls](http://www.slideshare.net/LegalizeAdulthood/c-traps-and-pitfalls-for-c-programmers).
+
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
We are working towards making exercises stand-alone. That is to say: no more generating READMEs on the fly.

This will give maintainers more control over each individual exercise README, and it will also make some of the backend logic for delivering exercises simpler.

The README template uses the Go text/template package, and the default templates generate the same READMEs as we have been generating on the fly.  See the documentation in [regenerating exercise readmes][regenerate-docs] for details.

The READMEs can be generated at any time using a new 'generate' command in configlet. This command has not yet landed in master or been released, but can be built from source in the generate-readmes branch on [configlet][].

[configlet]: https://github.com/exercism/configlet
[regenerate-docs]: https://github.com/exercism/docs/blob/master/maintaining-a-track/regenerating-exercise-readmes.md

See https://github.com/exercism/meta/issues/15