### PR TITLE
Prepare ABOUT.md for nextercism

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,42 +1,17 @@
-[C++](https://en.wikipedia.org/wiki/C%2B%2B) (pronounced cee plus plus)
-is a general purpose programming language developed by
-[Bjarne Stroustrup](https://en.wikipedia.org/wiki/Bjarne_Stroustrup)
-starting in 1979 at Bell Labs. It is  immensely  popular,  particularly
-for  applications  that  require  speed  and/or  access to  some
-low-level  features.  It is considered to be an intermediate level
-language, as it encapsulates both high and low level language features.
+[C++](https://en.wikipedia.org/wiki/C%2B%2B) (pronounced cee plus plus) is a general purpose programming language developed by [Bjarne Stroustrup](https://en.wikipedia.org/wiki/Bjarne_Stroustrup) starting in 1979 at Bell Labs. It is  immensely  popular,  particularly for  applications  that  require  speed  and/or  access to  some low-level  features.  It is considered to be an intermediate level language, as it encapsulates both high and low level language features.
 
-C++ supports [procedural](https://en.wikipedia.org/wiki/Procedural_programming),
-[object-oriented](https://en.wikipedia.org/wiki/Object-oriented_programming),
-[functional](https://en.wikipedia.org/wiki/Functional_programming)
-and [generic](https://en.wikipedia.org/wiki/Generic_programming)
-programming. Compilers for C++ are available for essentially every platform,
-including Windows, Mac OS, and Linux.
+C++ supports [procedural](https://en.wikipedia.org/wiki/Procedural_programming), [object-oriented](https://en.wikipedia.org/wiki/Object-oriented_programming), [functional](https://en.wikipedia.org/wiki/Functional_programming) and [generic](https://en.wikipedia.org/wiki/Generic_programming) programming. Compilers for C++ are available for essentially every platform, including Windows, Mac OS, and Linux.
 
 Key Benefits:
-- Type safety
-    - Encapsulate necessary unsafe operations
-- Resource safety
-    - Not all resource management is managing memory
-- Performance
-    - For some parts of almost all systems, it's important
-- Predictability
-    - For hard and soft real-time systems
-- Teachability
-    - Complexity of code should be proportional to the complexity of the task
-- Readability
-    - People and machines ("analyzability")
-- Direct map to hardware
-    - of instructions and fundamental data types
-- Zero-overhead abstraction
-    - Classes with constructors and destructors, inheritance, generic
-    programming, functional programming techniques
+- **Type safety:** Encapsulate necessary unsafe operations
+- **Resource safety:** Not all resource management is managing memory
+- **Performance:** For some parts of almost all systems, it's important
+- **Predictability:** For hard and soft real-time systems
+- **Teachability:** Complexity of code should be proportional to the complexity of the task
+- **Readability:** People and machines ("analyzability")
+- **Direct map to hardware:** of instructions and fundamental data types
+- **Zero-overhead abstraction:** Classes with constructors and destructors, inheritance, generic programming, functional programming techniques
 
-The standard for C++ is maintained by the International Organization for
-Standardization (ISO), and the current version of C++ as of December
-2014 is C++14 (named not as the 14th version of C++, but rather
-signifying that the standard was ratified in 2014).
+The standard for C++ is maintained by the International Organization for Standardization (ISO), and the current version of C++ as of December 2014 is C++14 (named not as the 14th version of C++, but rather signifying that the standard was ratified in 2014).
 
-The best thing about C++ is that it runs on everything from embedded
-processors with very limited resources to the largest mainframe
-supercomputer and every personal computer in between.
+The best thing about C++ is that it runs on everything from embedded processors with very limited resources to the largest mainframe supercomputer and every personal computer in between.


### PR DESCRIPTION
Hello :)

On nextercism the ABOUT.md is currently rendered like this:
<img width="1167" alt="screen shot 2017-08-06 at 15 16 34" src="https://user-images.githubusercontent.com/286476/29004104-1b622206-7aba-11e7-9918-a6fc63886d3a.png">

I have removed line breaks and the double bullet points to make it look lots nicer. I have not edited the content itself. It will now render like this (the space on the right for the code snippet)

<img width="1161" alt="screen shot 2017-08-06 at 15 15 43" src="https://user-images.githubusercontent.com/286476/29004094-022f568c-7aba-11e7-8ce7-a3046aaf49b6.png">

See https://github.com/exercism/meta/issues/84 for more details.