### PR TITLE
Clarify type of gigasecond return value to avoid template edgecase.

### DIFF
--- a/exercises/gigasecond/gigasecond_test.cpp
+++ b/exercises/gigasecond/gigasecond_test.cpp
@@ -9,7 +9,7 @@ using namespace boost::posix_time;
 
 BOOST_AUTO_TEST_CASE(test_1)
 {
-    const auto actual = gigasecond::advance(time_from_string("2011-04-25 00:00:00"));
+    const ptime actual = gigasecond::advance(time_from_string("2011-04-25 00:00:00"));
 
     const ptime expected(time_from_string("2043-01-01 01:46:40"));
     BOOST_REQUIRE_EQUAL(expected, actual);


### PR DESCRIPTION
As pointed out in #139, the template errors thrown by the gigasecond test if you have an incorrect return type can be _really_ bad. This just gives a hint to the correct return type to avoid that problem in the future.

Closes #139 