### PR TITLE
Update crypto-square tests.

### DIFF
--- a/exercises/crypto-square/crypto_square_test.cpp
+++ b/exercises/crypto-square/crypto_square_test.cpp
@@ -2,71 +2,85 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(normalize_strange_characters)
+BOOST_AUTO_TEST_CASE(normalize_capitals)
 {
-    BOOST_REQUIRE_EQUAL("splunk", crypto_square::cipher("s#$%^&plunk").normalize_plain_text());
+    BOOST_REQUIRE_EQUAL("hello", crypto_square::cipher("Hello").normalize_plain_text());
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
+BOOST_AUTO_TEST_CASE(normalize_spaces)
+{
+    BOOST_REQUIRE_EQUAL("hithere", crypto_square::cipher("Hi there").normalize_plain_text());
+}
+
 BOOST_AUTO_TEST_CASE(normalize_numbers)
 {
     BOOST_REQUIRE_EQUAL("123go", crypto_square::cipher("1, 2, 3 GO!").normalize_plain_text());
 }
 
-BOOST_AUTO_TEST_CASE(size_of_small_square)
+BOOST_AUTO_TEST_CASE(plain_text_empty)
 {
-    BOOST_REQUIRE_EQUAL(2U, crypto_square::cipher("1234").size());
+    const std::vector<std::string> expected{};
+
+    const auto actual = crypto_square::cipher("").plain_text_segments();
+
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
 }
 
-BOOST_AUTO_TEST_CASE(size_of_slightly_larger_square)
+BOOST_AUTO_TEST_CASE(plain_text_4_characters)
 {
-    BOOST_REQUIRE_EQUAL(3U, crypto_square::cipher("123456789").size());
+    const std::vector<std::string> expected{"ab", "cd"};
+
+    const auto actual = crypto_square::cipher("Ab Cd").plain_text_segments();
+
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
 }
 
-BOOST_AUTO_TEST_CASE(size_of_non_perfect_square)
+BOOST_AUTO_TEST_CASE(plain_text_9_characters)
 {
-    BOOST_REQUIRE_EQUAL(4U, crypto_square::cipher("123456789abc").size());
+    const std::vector<std::string> expected{"thi", "sis", "fun"};
+
+    const auto actual = crypto_square::cipher("This is fun!").plain_text_segments();
+
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
 }
 
 BOOST_AUTO_TEST_CASE(plain_text_segments_from_phrase)
 {
-    const std::vector<std::string> expected{"neverv", "exthin", "eheart", "withid", "lewoes"};
+    const std::vector<std::string> expected{"ifmanwas", "meanttos", "tayonthe", "groundgo", "dwouldha", "vegivenu", "sroots"};
 
-    const auto actual = crypto_square::cipher("Never vex thine heart with idle woes").plain_text_segments();
-
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
-}
-
-BOOST_AUTO_TEST_CASE(plain_text_segments_from_complex_phrase)
-{
-    const std::vector<std::string> expected{"zomg", "zomb", "ies"};
-
-    const auto actual = crypto_square::cipher("ZOMG! ZOMBIES!!!").plain_text_segments();
+    const auto actual = crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").plain_text_segments();
 
     BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
 }
 
-BOOST_AUTO_TEST_CASE(cipher_text_short_phrase)
+BOOST_AUTO_TEST_CASE(cipher_text_empty_phrase)
 {
-    BOOST_REQUIRE_EQUAL("tasneyinicdsmiohooelntuillibsuuml",
-        crypto_square::cipher("Time is an illusion. Lunchtime doubly so.").cipher_text());
+    BOOST_REQUIRE_EQUAL("",
+        crypto_square::cipher("").cipher_text());
 }
 
 BOOST_AUTO_TEST_CASE(cipher_text_long_phrase)
 {
-    BOOST_REQUIRE_EQUAL("wneiaweoreneawssciliprerlneoidktcms",
-        crypto_square::cipher("We all know interspecies romance is weird.").cipher_text());
+    BOOST_REQUIRE_EQUAL("imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau",
+        crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").cipher_text());
 }
 
-BOOST_AUTO_TEST_CASE(normalized_cipher_text1)
+BOOST_AUTO_TEST_CASE(normalized_cipher_text_empty)
 {
-    BOOST_REQUIRE_EQUAL("msemoa anindn inndla etltsh ui",
-        crypto_square::cipher("Madness, and then illumination.").normalized_cipher_text());
+    BOOST_REQUIRE_EQUAL("",
+        crypto_square::cipher("").normalized_cipher_text());
 }
 
-BOOST_AUTO_TEST_CASE(normalized_cipher_text2)
+BOOST_AUTO_TEST_CASE(normalized_cipher_text_fun)
 {
-    BOOST_REQUIRE_EQUAL("vrela epems etpao oirpo",
-        crypto_square::cipher("Vampires are people too!").normalized_cipher_text());
+    BOOST_REQUIRE_EQUAL("tsf hiu isn",
+        crypto_square::cipher("This is fun!").normalized_cipher_text());
+}
+
+BOOST_AUTO_TEST_CASE(normalized_cipher_text_long_phrase)
+{
+    BOOST_REQUIRE_EQUAL("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ",
+        crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").normalized_cipher_text());
 }
 #endif

--- a/exercises/crypto-square/example.cpp
+++ b/exercises/crypto-square/example.cpp
@@ -63,10 +63,10 @@ string cipher::cipher_text() const
 string cipher::normalized_cipher_text() const
 {
     const auto num_rows = size();
-    const auto plain{plain_text_segments()};
+    const auto plain = plain_text_segments();
     string result;
     for (size_t i = 0; i < num_rows; ++i) {
-        for (const auto s : plain) {
+        for (string const& s : plain) {
             if (s.length() > i) {
                 result += s[i];
             }

--- a/exercises/crypto-square/example.cpp
+++ b/exercises/crypto-square/example.cpp
@@ -34,7 +34,7 @@ string cipher::normalize_plain_text() const
 
 size_t cipher::size() const
 {
-    size_t length = 1;
+    size_t length = 0;
     while (length*length < text_.size()) {
         ++length;
     }
@@ -53,27 +53,31 @@ vector<string> cipher::plain_text_segments() const
 
 string cipher::cipher_text() const
 {
-    string result;
-    const vector<string> segments{plain_text_segments()};
-    const size_t rows{size()};
-    const size_t num_segments{segments.size()};
-    for (size_t i = 0; i < rows; ++i) {
-        for (size_t j = 0; j < num_segments; ++j) {
-            if (i < segments[j].length()) {
-                result += segments[j][i];
-            }
-        }
+    string s{normalized_cipher_text()};
+    if (!s.empty()) {
+        s.erase(remove(s.begin(), s.end(), ' '), s.end());
     }
-    return result;
+    return s;
 }
 
 string cipher::normalized_cipher_text() const
 {
-    const string encoded{cipher_text()};
     const auto num_rows = size();
-    string result{encoded.substr(0, num_rows)};
-    for (auto i = num_rows; i < encoded.length(); i += num_rows) {
-        result += ' ' + encoded.substr(i, num_rows);
+    const auto plain{plain_text_segments()};
+    string result;
+    for (size_t i = 0; i < num_rows; ++i) {
+        for (const auto s : plain) {
+            if (s.length() > i) {
+                result += s[i];
+            }
+            else {
+                result += ' ';
+            }
+        }
+        result += ' ';
+    }
+    if (!result.empty()) {
+        result.pop_back();
     }
     return result;
 }


### PR DESCRIPTION
Updates the crypto-square test suite (and the example solution) to match the description and canonical json. See #97.

This new test suite is incompatible with the old solutions. I still need to look into whether this needs to be marked as v2 or something before merging it.

Closes #97