### PR TITLE
Improve robot-name tests and remove Boost.Regex dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - sudo apt-get -y -d update
   - eval "${MATRIX_EVAL}"
 install:
-  - sudo apt-get -y install libboost-regex1.60-dev libboost-test1.60-dev libboost-date-time1.60-dev
+  - sudo apt-get -y install libboost-test1.60-dev libboost-date-time1.60-dev
 script:
   - bin/fetch-configlet
   - bin/configlet lint .

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -81,8 +81,8 @@ The unit tests use Boost.Test, the unit testing framework included with
 in Boost useful to you as you work through the exercises.
 You will need to download and install Boost.  As of this writing Boost
 1.59+ is the required version.  You will need a compiled version of the
-boost libraries Boost.Test, Boost.DateTime and Boost.Regex, or you will
-need to download from source and build the library yourself.
+boost libraries Boost.Test and Boost.DateTime or you will need to 
+download from source and build the library yourself.
 
 If you are having difficulties installing Boost for use with exercism,
 [ask for help](https://github.com/exercism/cpp/issues).
@@ -143,7 +143,6 @@ CMake Error at C:/Program Files (x86)/CMake 2.8/share/cmake-2.8/Modules/FindBoos
 
           boost_unit_test_framework
           boost_date_time
-          boost_regex
 
   No Boost libraries were found.  You may need to set BOOST_LIBRARYDIR to the
   directory containing Boost libraries or BOOST_ROOT to the location of

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,20 +1,22 @@
 #include "robot_name.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/regex.hpp>
+#include <regex>
+#include <string>
+#include <unordered_set>
 
 using namespace std;
 
 namespace
 {
-const boost::regex name_pattern{R"name(^[[:upper:]]{2}\d{3}$)name"};
+const regex name_pattern("[A-Z]{2}[0-9]{3}");
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)
 {
     const robot_name::robot robot;
 
-    BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+    BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -46,12 +48,14 @@ BOOST_AUTO_TEST_CASE(is_able_to_reset_name)
 BOOST_AUTO_TEST_CASE(exhausting_digits_yields_different_names)
 {
     robot_name::robot robot;
-    auto last_name = robot.name();
+    unordered_set<string> names;
+    names.insert(robot.name());
 
     for (int i = 0; i < 1000; ++i) {
         robot.reset();
-        BOOST_REQUIRE_NE(last_name, robot.name());
-        BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+        BOOST_REQUIRE_EQUAL(names.count(robot.name()), 0);
+        BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
+        names.insert(robot.name());
     }
 }
 #endif

--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,22 +1,25 @@
 #include "robot_name.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <regex>
+#include <cctype>
 #include <string>
 #include <unordered_set>
 
 using namespace std;
 
-namespace
+static bool validate_name(string name)
 {
-const regex name_pattern("[A-Z]{2}[0-9]{3}");
+    if (name.length() != 5)
+        return false;
+    return isupper(name[0]) && isupper(name[1]) && isdigit(name[2])
+        && isdigit(name[3]) && isdigit(name[4]);
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)
 {
     const robot_name::robot robot;
 
-    BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
+    BOOST_REQUIRE(validate_name(robot.name()));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -54,7 +57,7 @@ BOOST_AUTO_TEST_CASE(exhausting_digits_yields_different_names)
     for (int i = 0; i < 1000; ++i) {
         robot.reset();
         BOOST_REQUIRE_EQUAL(names.count(robot.name()), 0);
-        BOOST_REQUIRE(regex_match(robot.name(), name_pattern));
+        BOOST_REQUIRE(validate_name(robot.name()));
         names.insert(robot.name());
     }
 }

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 2.8.11)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Enable C++11 features on gcc/clang
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")


### PR DESCRIPTION
Improves the tests for robot-name (making sure that it can generate at least 1000 unique robot names), and transition to `std::regex` instead of Boost.Regex.

The use of Boost.Regex only existed because GCC hadn't instituted `std::regex` support at the time of original writing.