### PR TITLE
Fix invalid uuids

### DIFF
--- a/config.json
+++ b/config.json
@@ -407,7 +407,7 @@
         "strings"
       ],
       "unlocked_by": null,
-      "uuid": "ba4e0186-0389-af80-d3e4-695dfc4e63bff1fa503"
+      "uuid": "15c741a0-944d-4b06-a096-6af63137347a"
     },
     {
       "core": false,
@@ -418,7 +418,7 @@
         "stacks"
       ],
       "unlocked_by": null,
-      "uuid": "ce9fd8ac-0beb-1a80-4ff6-be19ce1540d905c31b7"
+      "uuid": "4a517292-3472-40f2-b4b8-5c8c25219ea5"
     },
     {
       "core": false,
@@ -429,7 +429,7 @@
         "strings"
       ],
       "unlocked_by": null,
-      "uuid": "ea8d6224-0440-6d80-1569-a04127908a200d2ecf0"
+      "uuid": "22ada9c4-a2b5-4a54-83d6-597dc3b90b89"
     }
   ],
   "foregone": [


### PR DESCRIPTION
Configlet previously could generate invalid uuids.

It looks as though `atbash-cipher`, `bracket-push` and `pangram` had invalid uuids.