### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,7 +106,8 @@
       "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops"
+        "control_flow_loops",
+        "math"
       ]
     },
     {
@@ -172,7 +173,7 @@
       "unlocked_by": "gigasecond",
       "difficulty": 3,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -214,8 +215,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "mathematics"
+        "control_flow_conditionals"
       ]
     },
     {
@@ -245,7 +245,6 @@
       "unlocked_by": "grains",
       "difficulty": 7,
       "topics": [
-        "mathematics",
         "strings"
       ]
     },
@@ -256,7 +255,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "mathematics",
+        "math",
         "strings"
       ]
     },
@@ -268,7 +267,7 @@
       "difficulty": 5,
       "topics": [
         "control_flow_loops",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -290,7 +289,7 @@
       "unlocked_by": "triangle",
       "difficulty": 3,
       "topics": [
-        "mathematics",
+        "math",
         "strings"
       ]
     },
@@ -324,7 +323,7 @@
       "difficulty": 5,
       "topics": [
         "control_flow_loops",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -368,7 +367,7 @@
       "unlocked_by": "leap",
       "difficulty": 5,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -378,7 +377,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "mathematics",
+        "math",
         "strings"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110