### PR TITLE
Add missing include to "meetup" exercise test file

### DIFF
--- a/exercises/meetup/meetup_test.cpp
+++ b/exercises/meetup/meetup_test.cpp
@@ -1,5 +1,6 @@
 #include "meetup.h"
 #define BOOST_TEST_MAIN
+#include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/test/unit_test.hpp>
 
 // See <http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html>


### PR DESCRIPTION
This diff addresses the following issue where the tests assume the streaming operators will be included in `meetup.h`. We should not force this dependency on the user's code.

Clang++ `6.0.1`
Boost version: `1.67.0_1`

# Error
```
[ 33%] Building CXX object CMakeFiles/meetup.dir/meetup_test.cpp.o
In file included from /Users/collen/exercism/cpp/meetup/meetup_test.cpp:3:
In file included from /usr/local/include/boost/test/unit_test.hpp:18:
In file included from /usr/local/include/boost/test/test_tools.hpp:46:
In file included from /usr/local/include/boost/test/tools/old/impl.hpp:24:
/usr/local/include/boost/test/tools/detail/print_helper.hpp:52:13: error: static_assert failed due to requirement 'boost::has_left_shift<std::ostream,
      date>::value' "Type has to implement operator<< to be printable"
            BOOST_STATIC_ASSERT_MSG( (boost::has_left_shift<std::ostream,T>::value),
            ^                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/static_assert.hpp:31:45: note: expanded from macro 'BOOST_STATIC_ASSERT_MSG'
#     define BOOST_STATIC_ASSERT_MSG( ... ) static_assert(__VA_ARGS__)
                                            ^             ~~~~~~~~~~~
/usr/local/include/boost/test/tools/detail/print_helper.hpp:61:24: note: in instantiation of function template specialization
      'boost::test_tools::tt_detail::impl::boost_test_print_type<boost::gregorian::date>' requested here
                return boost_test_print_type(ostr, r);
                       ^
/usr/local/include/boost/test/tools/detail/print_helper.hpp:90:9: note: in instantiation of function template specialization
      'boost::test_tools::tt_detail::impl::boost_test_print_type_impl::operator()<boost::gregorian::date>' requested here
        boost_test_print_type(ostr, t);
        ^
/usr/local/include/boost/test/tools/detail/print_helper.hpp:219:5: note: in instantiation of member function
      'boost::test_tools::tt_detail::print_log_value<boost::gregorian::date>::operator()' requested here
    print_log_value<T>()( ostr, ph.m_t );
    ^
/usr/local/include/boost/test/utils/lazy_ostream.hpp:66:29: note: in instantiation of function template specialization
      'boost::test_tools::tt_detail::operator<<<boost::gregorian::date>' requested here
        return m_prev(ostr) << m_value;
                            ^
/usr/local/include/boost/test/tools/old/impl.hpp:92:50: note: in instantiation of member function
      'boost::unit_test::lazy_ostream_impl<boost::unit_test::lazy_ostream, boost::test_tools::tt_detail::print_helper_t<boost::gregorian::date>, const
      boost::test_tools::tt_detail::print_helper_t<boost::gregorian::date> &>::operator()' requested here
BOOST_PP_REPEAT( BOOST_TEST_MAX_PREDICATE_ARITY, IMPL_FRWD, _ )
                                                 ^
/usr/local/include/boost/preprocessor/repetition/repeat.hpp:29:26: note: expanded from macro 'BOOST_PP_REPEAT'
# define BOOST_PP_REPEAT BOOST_PP_CAT(BOOST_PP_REPEAT_, BOOST_PP_AUTO_REC(BOOST_PP_REPEAT_P, 4))
                         ^
/usr/local/include/boost/preprocessor/cat.hpp:22:32: note: expanded from macro 'BOOST_PP_CAT'
#    define BOOST_PP_CAT(a, b) BOOST_PP_CAT_I(a, b)
                               ^
/usr/local/include/boost/preprocessor/cat.hpp:29:34: note: expanded from macro 'BOOST_PP_CAT_I'
#    define BOOST_PP_CAT_I(a, b) a ## b
                                 ^
<scratch space>:67:1: note: expanded from here
BOOST_PP_REPEAT_1
^
/Users/collen/exercism/cpp/meetup/meetup_test.cpp:13:5: note: in instantiation of function template specialization
      'boost::test_tools::tt_detail::check_frwd<boost::test_tools::tt_detail::equal_impl_frwd, boost::gregorian::date, boost::gregorian::date>'
      requested here
    BOOST_REQUIRE_EQUAL(expected, meetup.monteenth());
    ^
/usr/local/include/boost/test/tools/old/interface.hpp:154:45: note: expanded from macro 'BOOST_REQUIRE_EQUAL'
#define BOOST_REQUIRE_EQUAL( L, R )         BOOST_TEST_TOOL_IMPL( 0, \
                                            ^
/usr/local/include/boost/test/tools/old/interface.hpp:65:47: note: expanded from macro 'BOOST_TEST_TOOL_IMPL'
    BOOST_PP_IF( frwd_type, report_assertion, check_frwd ) (                    \
                                              ^
In file included from /Users/collen/exercism/cpp/meetup/meetup_test.cpp:3:
In file included from /usr/local/include/boost/test/unit_test.hpp:18:
In file included from /usr/local/include/boost/test/test_tools.hpp:46:
In file included from /usr/local/include/boost/test/tools/old/impl.hpp:24:
/usr/local/include/boost/test/tools/detail/print_helper.hpp:54:18: error: invalid operands to binary expression ('std::ostream'
      (aka 'basic_ostream<char>') and 'const boost::gregorian::date')
            ostr << t;
            ~~~~ ^  ~
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:218:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'const void *' for 1st argument; take the address of the argument with &
    basic_ostream& operator<<(const void* __p);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:194:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'std::__1::basic_ostream<char> &(*)(std::__1::basic_ostream<char> &)' for 1st argument
    basic_ostream& operator<<(basic_ostream& (*__pf)(basic_ostream&))
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:198:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'basic_ios<std::__1::basic_ostream<char, std::__1::char_traits<char> >::char_type,
      std::__1::basic_ostream<char, std::__1::char_traits<char> >::traits_type> &(*)(basic_ios<std::__1::basic_ostream<char,
      std::__1::char_traits<char> >::char_type, std::__1::basic_ostream<char, std::__1::char_traits<char> >::traits_type> &)' (aka 'basic_ios<char,
      std::__1::char_traits<char> > &(*)(basic_ios<char, std::__1::char_traits<char> > &)') for 1st argument
    basic_ostream& operator<<(basic_ios<char_type, traits_type>&
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:203:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'std::__1::ios_base &(*)(std::__1::ios_base &)' for 1st argument
    basic_ostream& operator<<(ios_base& (*__pf)(ios_base&))
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:206:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'bool' for 1st argument
    basic_ostream& operator<<(bool __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:207:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'short' for 1st argument
    basic_ostream& operator<<(short __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:208:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'unsigned short' for 1st argument
    basic_ostream& operator<<(unsigned short __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:209:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'int' for 1st argument
    basic_ostream& operator<<(int __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:210:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'unsigned int' for 1st argument
    basic_ostream& operator<<(unsigned int __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:211:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'long' for 1st argument
    basic_ostream& operator<<(long __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:212:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'unsigned long' for 1st argument
    basic_ostream& operator<<(unsigned long __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:213:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'long long' for 1st argument
    basic_ostream& operator<<(long long __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:214:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'unsigned long long' for 1st argument
    basic_ostream& operator<<(unsigned long long __n);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:215:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'float' for 1st argument
    basic_ostream& operator<<(float __f);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:216:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'double' for 1st argument
    basic_ostream& operator<<(double __f);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:217:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'long double' for 1st argument
    basic_ostream& operator<<(long double __f);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:219:20: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'basic_streambuf<std::__1::basic_ostream<char, std::__1::char_traits<char> >::char_type,
      std::__1::basic_ostream<char, std::__1::char_traits<char> >::traits_type> *' (aka 'basic_streambuf<char, std::__1::char_traits<char> > *') for
      1st argument
    basic_ostream& operator<<(basic_streambuf<char_type, traits_type>* __sb);
                   ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:755:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'char' for 2nd argument
operator<<(basic_ostream<_CharT, _Traits>& __os, char __cn)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:788:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'char' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, char __c)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:795:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'signed char' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, signed char __c)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:802:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'unsigned char' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, unsigned char __c)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:816:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'const char *' for 2nd argument
operator<<(basic_ostream<_CharT, _Traits>& __os, const char* __strn)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:862:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'const char *' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, const char* __str)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:869:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'const signed char *' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, const signed char* __str)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:877:1: note: candidate function not viable: no known conversion from 'const boost::gregorian::date'
      to 'const unsigned char *' for 2nd argument
operator<<(basic_ostream<char, _Traits>& __os, const unsigned char* __str)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1061:1: note: candidate function not viable: no known conversion from
      'const boost::gregorian::date' to 'const std::__1::error_code' for 2nd argument
operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __ec)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:748:1: note: candidate template ignored: deduced conflicting types for parameter '_CharT'
      ('char' vs. 'boost::gregorian::date')
operator<<(basic_ostream<_CharT, _Traits>& __os, _CharT __c)
^
/usr/local/include/boost/smart_ptr/shared_ptr.hpp:991:64: note: candidate template ignored: could not match 'shared_ptr<type-parameter-0-2>' against
      'const boost::gregorian::date'
template<class E, class T, class Y> std::basic_ostream<E, T> & operator<< (std::basic_ostream<E, T> & os, shared_ptr<Y> const & p)
                                                               ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:809:1: note: candidate template ignored: could not match 'const _CharT *' against
      'boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os, const _CharT* __str)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1044:1: note: candidate template ignored: could not match 'basic_string<type-parameter-0-0,
      type-parameter-0-1, type-parameter-0-2>' against 'const boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os,
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1069:1: note: candidate template ignored: could not match 'shared_ptr<type-parameter-0-2>' against
      'const boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os, shared_ptr<_Yp> const& __p)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1090:1: note: candidate template ignored: could not match 'bitset<_Size>' against
      'const boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os, const bitset<_Size>& __x)
^
/usr/local/include/boost/test/utils/wrap_stringstream.hpp:64:1: note: candidate template ignored: could not match 'basic_wrap_stringstream' against
      'basic_ostream'
operator<<( basic_wrap_stringstream<CharT>& targ, T const& t )
^
/usr/local/include/boost/test/utils/wrap_stringstream.hpp:109:1: note: candidate template ignored: could not match 'basic_wrap_stringstream' against
      'basic_ostream'
operator<<( basic_wrap_stringstream<CharT>& targ, basic_wrap_stringstream<CharT>& src )
^
/usr/local/include/boost/test/utils/wrap_stringstream.hpp:121:1: note: candidate template ignored: could not match 'basic_wrap_stringstream' against
      'basic_ostream'
operator<<( basic_wrap_stringstream<CharT>& targ, std::ios_base& (BOOST_TEST_CALL_DECL *man)(std::ios_base&) )
^
/usr/local/include/boost/test/utils/wrap_stringstream.hpp:131:1: note: candidate template ignored: could not match 'basic_wrap_stringstream' against
      'basic_ostream'
operator<<( basic_wrap_stringstream<CharT>& targ, std::basic_ostream<Elem,Tr>& (BOOST_TEST_CALL_DECL *man)(std::basic_ostream<Elem, Tr>&) )
^
/usr/local/include/boost/test/utils/wrap_stringstream.hpp:141:1: note: candidate template ignored: could not match 'basic_wrap_stringstream' against
      'basic_ostream'
operator<<( basic_wrap_stringstream<CharT>& targ, std::basic_ios<Elem, Tr>& (BOOST_TEST_CALL_DECL *man)(std::basic_ios<Elem, Tr>&) )
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1034:1: note: candidate template ignored: requirement '!is_lvalue_reference<basic_ostream<char>
      &>::value' was not satisfied [with _Stream = std::__1::basic_ostream<char> &, _Tp = boost::gregorian::date]
operator<<(_Stream&& __os, const _Tp& __x)
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1052:1: note: candidate template ignored: could not match 'basic_string_view<type-parameter-0-0,
      type-parameter-0-1>' against 'boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os,
^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/ostream:1082:1: note: candidate template ignored: could not match 'unique_ptr<type-parameter-0-2,
      type-parameter-0-3>' against 'const boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os, unique_ptr<_Yp, _Dp> const& __p)
^
/usr/local/include/boost/date_time/int_adapter.hpp:463:3: note: candidate template ignored: could not match 'int_adapter<type-parameter-0-2>' against
      'const boost::gregorian::date'
  operator<<(std::basic_ostream<charT, traits>& os, const int_adapter<int_type>& ia)
  ^
/usr/local/Cellar/llvm/6.0.1/include/c++/v1/complex:1431:1: note: candidate template ignored: could not match 'complex<type-parameter-0-0>' against
      'const boost::gregorian::date'
operator<<(basic_ostream<_CharT, _Traits>& __os, const complex<_Tp>& __x)
^
2 errors generated.
make[2]: *** [CMakeFiles/meetup.dir/meetup_test.cpp.o] Error 1
make[1]: *** [CMakeFiles/meetup.dir/all] Error 2
make: *** [all] Error 2
```