### PR TITLE
difference-of-squares: Rename square_of_sums to square_of_sum

### DIFF
--- a/exercises/difference-of-squares/difference_of_squares_test.cpp
+++ b/exercises/difference-of-squares/difference_of_squares_test.cpp
@@ -4,7 +4,7 @@
 
 BOOST_AUTO_TEST_CASE(up_to_5)
 {
-    BOOST_REQUIRE_EQUAL(225, squares::square_of_sums(5));
+    BOOST_REQUIRE_EQUAL(225, squares::square_of_sum(5));
     BOOST_REQUIRE_EQUAL(55, squares::sum_of_squares(5));
     BOOST_REQUIRE_EQUAL(170, squares::difference(5));
 }
@@ -12,14 +12,14 @@ BOOST_AUTO_TEST_CASE(up_to_5)
 #if defined(EXERCISM_RUN_ALL_TESTS)
 BOOST_AUTO_TEST_CASE(up_to_10)
 {
-    BOOST_REQUIRE_EQUAL(3025, squares::square_of_sums(10));
+    BOOST_REQUIRE_EQUAL(3025, squares::square_of_sum(10));
     BOOST_REQUIRE_EQUAL(385, squares::sum_of_squares(10));
     BOOST_REQUIRE_EQUAL(2640, squares::difference(10));
 }
 
 BOOST_AUTO_TEST_CASE(up_to_100)
 {
-    BOOST_REQUIRE_EQUAL(25502500, squares::square_of_sums(100));
+    BOOST_REQUIRE_EQUAL(25502500, squares::square_of_sum(100));
     BOOST_REQUIRE_EQUAL(338350, squares::sum_of_squares(100));
     BOOST_REQUIRE_EQUAL(25164150, squares::difference(100));
 }

--- a/exercises/difference-of-squares/example.cpp
+++ b/exercises/difference-of-squares/example.cpp
@@ -6,7 +6,7 @@ using namespace std;
 namespace squares
 {
 
-int square_of_sums(int n)
+int square_of_sum(int n)
 {
     int sum = 0;
     for (int i = 1; i <= n; ++i) {
@@ -26,7 +26,7 @@ int sum_of_squares(int n)
 
 int difference(int n)
 {
-    return square_of_sums(n) - sum_of_squares(n);
+    return square_of_sum(n) - sum_of_squares(n);
 }
 
 }

--- a/exercises/difference-of-squares/example.h
+++ b/exercises/difference-of-squares/example.h
@@ -4,7 +4,7 @@
 namespace squares
 {
 
-int square_of_sums(int n);
+int square_of_sum(int n);
 int sum_of_squares(int n);
 int difference(int n);
 


### PR DESCRIPTION
In the exercise "difference-of-squares", I changed `square_of_sums` to `square_of_sum`.

This change is similar to the one done in the  [Haskell track](https://github.com/exercism/haskell/pull/711).