### PR TITLE
Run tests on hello-world exercise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ function(travis_fixup dir)
 endfunction()
 
 foreach(exercise
+    hello-world
     bob
     word-count
     hamming


### PR DESCRIPTION
A full build skips the `hello-world` exercise entirely.

Is there any reason that we should avoid this exercise?