### PR TITLE
Cmake update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,9 @@ before_install:
   - sudo apt-get -y -d update
   - eval "${MATRIX_EVAL}"
 install:
-  - sudo apt-get -y install libboost-regex1.60-dev libboost-test1.60-dev libboost-date-time1.60-dev
+  - sudo apt-get -y install cmake3 libboost-regex1.60-dev libboost-test1.60-dev libboost-date-time1.60-dev
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
   - cmake -G "Unix Makefiles"
   - make
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false 
+sudo: false
 language: cpp
 
 matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 project(exercism CXX)
 
 function(travis_fixup dir)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ function(travis_fixup dir)
     endif()
 endfunction()
 
+option(EXERCISM_RUN_ALL_TESTS "Run all Exercism tests" On)
+
 foreach(exercise
     bob
     word-count
@@ -52,12 +54,6 @@ foreach(exercise
     bracket-push
     pangram
 )
-    set(exercise_dir exercises/${exercise})
     travis_fixup(${exercise})
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -DEXERCISM_RUN_ALL_TESTS:BOOL=1 -G ${CMAKE_GENERATOR} .
-        WORKING_DIRECTORY ${exercise_dir})
-    add_custom_target(${exercise} ALL
-        COMMAND ${CMAKE_COMMAND} --build .
-        WORKING_DIRECTORY ${exercise_dir})
+    add_subdirectory(exercises/${exercise})
 endforeach()

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -72,7 +72,7 @@ systems.  If you encounter any problems with the supplied CMake recipe,
 please [report the issue](https://github.com/exercism/cpp/issues) so we can
 improve the CMake support.
 
-[CMake 2.8.11 or later](http://www.cmake.org/) is required to use the provided build recipe.
+[CMake 3.1.3 or later](http://www.cmake.org/) is required to use the provided build recipe.
 
 ### Prerequisite: Boost 1.59+
 

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -43,11 +43,13 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     )
 endif()
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
-
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+    Boost::regex
+)
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
 # Configure to run all the tests?
 if(${EXERCISM_RUN_ALL_TESTS})
     add_definitions(-DEXERCISM_RUN_ALL_TESTS)
@@ -35,6 +30,12 @@ endif()
 
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -37,6 +37,12 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
+
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
 

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -49,4 +49,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -13,11 +13,6 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
-
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
 
@@ -50,6 +45,11 @@ target_link_libraries(${exercise}
     Boost::date_time
     Boost::regex
 )
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})


### PR DESCRIPTION
Stylistic updates to `CMakeLists.txt` files as discussed in #205.
Compiler standard is left at `C++11`. `C++14` breaks the Clang build; see #189.