### PR TITLE
Fix broken link in Hello World readme

### DIFF
--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -16,7 +16,7 @@ If everything goes well, you will be ready to fetch your first real exercise.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and 
 [Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
 This covers the basic information on setting up the development
 environment expected by the exercises.


### PR DESCRIPTION
The readme for the Hello World has a broken "installing" link n the ## Getting Started section