### PR TITLE
moved to use enum class

### DIFF
--- a/exercises/triangle/example.cpp
+++ b/exercises/triangle/example.cpp
@@ -25,12 +25,12 @@ flavor kind(double a, double b, double c)
         throw std::domain_error("Invalid triangle");
     }
     if (a == b && b == c) {
-        return equilateral;
+        return flavor::equilateral;
     }
     if (a == b || b == c || a == c) {
-        return isosceles;
+        return flavor::isosceles;
     }
-    return scalene;
+    return flavor::scalene;
 }
 
 }

--- a/exercises/triangle/example.h
+++ b/exercises/triangle/example.h
@@ -4,7 +4,7 @@
 namespace triangle
 {
 
-enum flavor
+enum class flavor
 {
     equilateral,
     isosceles,

--- a/exercises/triangle/triangle_test.cpp
+++ b/exercises/triangle/triangle_test.cpp
@@ -3,55 +3,57 @@
 #include <boost/test/unit_test.hpp>
 #include <stdexcept>
 
+BOOST_TEST_DONT_PRINT_LOG_VALUE(triangle::flavor)
+
 BOOST_AUTO_TEST_CASE(equilateral_triangles_have_equal_sides)
 {
-    BOOST_REQUIRE_EQUAL(triangle::equilateral, triangle::kind(2, 2, 2));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::equilateral, triangle::kind(2, 2, 2));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 BOOST_AUTO_TEST_CASE(larger_equilateral_triangles_also_have_equal_sides)
 {
-    BOOST_REQUIRE_EQUAL(triangle::equilateral, triangle::kind(10, 10, 10));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::equilateral, triangle::kind(10, 10, 10));
 }
 
 BOOST_AUTO_TEST_CASE(isosceles_triangles_have_last_two_sides_equal)
 {
-    BOOST_REQUIRE_EQUAL(triangle::isosceles, triangle::kind(3, 4, 4));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::isosceles, triangle::kind(3, 4, 4));
 }
 
 BOOST_AUTO_TEST_CASE(isosceles_triangles_have_first_and_last_sides_equal)
 {
-    BOOST_REQUIRE_EQUAL(triangle::isosceles, triangle::kind(4, 3, 4));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::isosceles, triangle::kind(4, 3, 4));
 }
 
 BOOST_AUTO_TEST_CASE(isosceles_triangles_have_first_two_sides_equal)
 {
-    BOOST_REQUIRE_EQUAL(triangle::isosceles, triangle::kind(4, 4, 3));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::isosceles, triangle::kind(4, 4, 3));
 }
 
 BOOST_AUTO_TEST_CASE(isosceles_triangles_have_in_fact_exactly_two_sides_equal)
 {
-    BOOST_REQUIRE_EQUAL(triangle::isosceles, triangle::kind(10, 10, 2));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::isosceles, triangle::kind(10, 10, 2));
 }
 
 BOOST_AUTO_TEST_CASE(scalene_triangles_have_no_equal_sides)
 {
-    BOOST_REQUIRE_EQUAL(triangle::scalene, triangle::kind(3, 4, 5));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::scalene, triangle::kind(3, 4, 5));
 }
 
 BOOST_AUTO_TEST_CASE(scalene_triangles_have_no_equal_sides_at_a_larger_scale_too)
 {
-    BOOST_REQUIRE_EQUAL(triangle::scalene, triangle::kind(10, 11, 12));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::scalene, triangle::kind(10, 11, 12));
 }
 
 BOOST_AUTO_TEST_CASE(scalene_triangles_have_no_equal_sides_in_descending_order_either)
 {
-    BOOST_REQUIRE_EQUAL(triangle::scalene, triangle::kind(5, 4, 2));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::scalene, triangle::kind(5, 4, 2));
 }
 
 BOOST_AUTO_TEST_CASE(very_small_triangles_are_legal)
 {
-    BOOST_REQUIRE_EQUAL(triangle::scalene, triangle::kind(0.4, 0.6, 0.3));
+    BOOST_REQUIRE_EQUAL(triangle::flavor::scalene, triangle::kind(0.4, 0.6, 0.3));
 }
 
 BOOST_AUTO_TEST_CASE(triangles_with_no_size_are_illegal)


### PR DESCRIPTION
I needed to put the `BOOST_TEST_DONT_PRINT_LOG_VALUE` as mentioned [here](https://stackoverflow.com/questions/30860241/use-enum-classes-with-boost-test).

The error messages are still readable and contain the actual expression.

This will break previous solutions.