### PR TITLE
Update readmes

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -6,7 +6,7 @@
 {{ end }}
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
 [Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -6,8 +6,8 @@
 {{ end }}
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -9,8 +9,9 @@ like Portable Network Graphics to its acronym (PNG).
 
 ## Getting Started
 
-Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
-exercism.io.  This covers the basic information on setting up the development
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
+This covers the basic information on setting up the development
 environment expected by the exercises.
 
 ## Passing the Tests

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -33,8 +33,8 @@ I think you got the idea!
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -31,8 +31,8 @@ score is 257, your program should only report the eggs (1) allergy.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -8,8 +8,8 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -30,8 +30,8 @@ things based on word boundaries.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -322,8 +322,8 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -32,8 +32,8 @@ So: `101 => 1*2^2 + 0*2^1 + 1*2^0 => 1*4 + 0*2 + 1*1 => 4 + 1 => 5 base 10`.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -13,8 +13,8 @@ He answers 'Whatever.' to anything else.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -6,8 +6,8 @@ and nested correctly.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -8,8 +8,8 @@ Two clocks that represent the same time should be equal to each other.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -74,8 +74,8 @@ ciphertext back in to the original message:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -12,10 +12,14 @@ Hence the difference between the square of the sum of the first
 ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
+You are not expected to discover an efficient solution to this yourself from
+first principles; research is allowed, indeed, encouraged. Finding the best
+algorithm for the problem is a key skill in software engineering.
+
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -48,8 +48,8 @@ game while being scored at 4 in the Hawaiian-language version.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -65,8 +65,8 @@ She's dead, of course!
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -7,8 +7,8 @@ A gigasecond is 10^9 (1,000,000,000) seconds.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -36,8 +36,8 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -6,14 +6,14 @@ on each square doubles.
 There once was a wise servant who saved the life of a prince. The king
 promised to pay whatever the servant could dream up. Knowing that the
 king loved chess, the servant told the king he would like to have grains
-of wheat. One grain on the first square of a chess board. Two grains on
-the next. Four on the third, and so on.
+of wheat. One grain on the first square of a chess board, with the number
+of grains doubling on each successive square.
 
-There are 64 squares on a chessboard.
+There are 64 squares on a chessboard (where square 1 has one grain, square 2 has two grains, and so on).
 
 Write code that shows:
-- how many grains were on each square, and
-- the total number of grains
+- how many grains were on a given square, and
+- the total number of grains on the chessboard
 
 ## For bonus points
 
@@ -28,8 +28,8 @@ experiment make the code better? Worse? Did you learn anything from it?
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -25,8 +25,8 @@ exception vs returning a special value) may differ between languages.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -16,8 +16,8 @@ If everything goes well, you will be ready to fetch your first real exercise.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -9,8 +9,8 @@ The program should handle invalid hexadecimal strings.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -13,9 +13,6 @@ on every year that is evenly divisible by 4
 For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
 year, but 2000 is.
 
-If your language provides a method in the standard library that does
-this look-up, pretend it doesn't exist and implement it yourself.
-
 ## Notes
 
 Though our exercise adopts some very simple rules, there is more to
@@ -28,8 +25,8 @@ phenomenon, go watch [this youtube video][video].
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -28,8 +28,8 @@ descriptor calculate the date of the actual meetup.  For example, if given
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -10,8 +10,8 @@ numbers, pretend they don't exist and implement them yourself.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -14,8 +14,8 @@ Here is an analogy:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -10,8 +10,8 @@ insensitive. Input will not contain non-ASCII symbols.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -30,8 +30,8 @@ should all produce the output
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -31,8 +31,8 @@ You can check this yourself:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -28,8 +28,8 @@ share a diagonal.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -19,8 +19,8 @@ Convert a number to a string, the contents of which depend on the number's facto
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -8,8 +8,9 @@ output: "looc"
 
 ## Getting Started
 
-Make sure you have read [the C++ page](http://exercism.io/languages/cpp) on
-exercism.io.  This covers the basic information on setting up the development
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
+This covers the basic information on setting up the development
 environment expected by the exercises.
 
 ## Passing the Tests

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -20,8 +20,8 @@ each nucleotide with its complement:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -17,8 +17,8 @@ every existing robot has a unique name.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -44,8 +44,8 @@ See also: http://www.novaroma.org/via_romana/numbers.html
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -64,8 +64,8 @@ Use _and_ (correctly) when spelling out the number in English:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -41,8 +41,8 @@ And to total:
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -22,8 +22,8 @@ in the input; the digits need not be *numerically consecutive*.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -31,8 +31,8 @@ language).
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -19,8 +19,8 @@ youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -10,8 +10,8 @@ The sum of these multiples is 78.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -24,8 +24,8 @@ a single line. Feel free to add your own code/tests to check for degenerate tria
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -23,8 +23,8 @@ conversion, pretend it doesn't exist and implement it yourself.
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -13,8 +13,8 @@ free: 1
 
 ## Getting Started
 
-Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installing) and 
-[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io. 
+Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installation) and
+[Running the Tests](https://exercism.io/tracks/cpp/tests) pages for C++ on exercism.io.
 This covers the basic information on setting up the development
 environment expected by the exercises.
 


### PR DESCRIPTION
The [docs/](https://github.com/exercism/cpp/tree/master/docs) directory contains `INSTALLATION.md`, so URLs in READMEs should refer to [installation](https://exercism.io/tracks/cpp/installation).

The current [README template](https://github.com/exercism/cpp/blob/06606387c73f694c23d336314e07db963f2024a7/config/exercise_readme.go.tmpl#L9) links to [installing](https://exercism.io/tracks/cpp/installing), which is a dead link.

Some READMEs are deployed correctly (Hello World), some incorrectly for varying reasons (Anagram, All Your Base).

Update link, then run configlet to update all READMEs.