### PR TITLE
Removing Boost::Regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - sudo apt-get -y -d update
   - eval "${MATRIX_EVAL}"
 install:
-  - sudo apt-get -y install cmake3 libboost-regex1.60-dev libboost-test1.60-dev libboost-date-time1.60-dev
+  - sudo apt-get -y install cmake3 libboost-test1.60-dev libboost-date-time1.60-dev
 script:
   - bin/fetch-configlet
   - bin/configlet lint .

--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -2,26 +2,16 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.1.3)
 
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
-
-# Enable C++11 features on gcc/clang
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
-
-# Configure to run all the tests?
-if(${EXERCISM_RUN_ALL_TESTS})
-    add_definitions(-DEXERCISM_RUN_ALL_TESTS)
-endif()
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -36,11 +26,29 @@ endif()
 # Build executable from sources and headers
 add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
-# We need boost includes
-target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})
+set_target_properties(${exercise} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED OFF
+    CXX_EXTENSIONS OFF
+)
+
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+    )
+endif()
 
 # We need boost libraries
-target_link_libraries(${exercise} ${Boost_LIBRARIES})
+target_link_libraries(${exercise}
+    PRIVATE
+    Boost::unit_test_framework
+    Boost::date_time
+)
+
+# Configure to run all the tests?
+if(${EXERCISM_RUN_ALL_TESTS})
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_RUN_ALL_TESTS)
+endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
@@ -49,4 +57,4 @@ if(${MSVC})
 endif()
 
 # Run the tests on every build
-add_custom_command(TARGET ${exercise} POST_BUILD COMMAND ${exercise})
+add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,20 +1,20 @@
 #include "robot_name.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 using namespace std;
 
 namespace
 {
-const boost::regex name_pattern{R"name(^[[:upper:]]{2}\d{3}$)name"};
+const std::regex name_pattern{"^[[:upper:]]{2}[[:digit:]]{3}$"};
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)
 {
     const robot_name::robot robot;
 
-    BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+    BOOST_REQUIRE(std::regex_match(robot.name(), name_pattern));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(exhausting_digits_yields_different_names)
     for (int i = 0; i < 1000; ++i) {
         robot.reset();
         BOOST_REQUIRE_NE(last_name, robot.name());
-        BOOST_REQUIRE(boost::regex_match(robot.name(), name_pattern));
+        BOOST_REQUIRE(std::regex_match(robot.name(), name_pattern));
     }
 }
 #endif

--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,20 +1,30 @@
 #include "robot_name.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <regex>
+#include <cctype>
+#include <string>
 
 using namespace std;
 
 namespace
 {
-const std::regex name_pattern{"^[[:upper:]]{2}[[:digit:]]{3}$"};
+// Helper function to check the robot name matches the instructions.
+//
+// 2 uppercase letters followed by 3 digits.
+static bool validate_name(const string& name)
+{
+    if (name.length() != 5)
+        return false;
+    return isupper(name[0]) && isupper(name[1]) && isdigit(name[2])
+        && isdigit(name[3]) && isdigit(name[4]);
+}
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)
 {
     const robot_name::robot robot;
 
-    BOOST_REQUIRE(std::regex_match(robot.name(), name_pattern));
+    BOOST_REQUIRE(validate_name(robot.name()));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -51,7 +61,7 @@ BOOST_AUTO_TEST_CASE(exhausting_digits_yields_different_names)
     for (int i = 0; i < 1000; ++i) {
         robot.reset();
         BOOST_REQUIRE_NE(last_name, robot.name());
-        BOOST_REQUIRE(std::regex_match(robot.name(), name_pattern));
+        BOOST_REQUIRE(validate_name(robot.name()));
     }
 }
 #endif

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -7,11 +7,11 @@ cmake_minimum_required(VERSION 3.1.3)
 # Name the project after the exercise
 project(${exercise} CXX)
 
-# Locate Boost libraries: unit_test_framework, date_time and regex
+# Locate Boost libraries: unit_test_framework and date_time
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time regex)
+find_package(Boost 1.59 REQUIRED COMPONENTS unit_test_framework date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})
@@ -43,7 +43,6 @@ target_link_libraries(${exercise}
     PRIVATE
     Boost::unit_test_framework
     Boost::date_time
-    Boost::regex
 )
 
 # Configure to run all the tests?


### PR DESCRIPTION
This removes the dependency on Boost::Regex by rewriting the one place we use it (the Robot Name test suite). Switching to `std::regex` wasn't possible because there are inconsistencies in older compilers' implementations.