### PR TITLE
C++ phone number tests

### DIFF
--- a/exercises/phone-number/example.cpp
+++ b/exercises/phone-number/example.cpp
@@ -1,6 +1,7 @@
 #include "phone_number.h"
 #include <algorithm>
 #include <cctype>
+#include <stdexcept>
 #include <iterator>
 #include <sstream>
 
@@ -13,7 +14,6 @@ const int area_code_length = 3;
 const int exchange_length = 3;
 const int extension_length = 4;
 const int valid_number_length = area_code_length + exchange_length + extension_length;
-const string cleaned_invalid_number(valid_number_length, '0');
 
 string clean_number(const string& text)
 {
@@ -24,10 +24,13 @@ string clean_number(const string& text)
         if (result[0] == '1') {
             result.erase(result.begin());
         } else {
-            result = cleaned_invalid_number;
+            throw std::domain_error("Invalid number");
         }
-    } else if (result.length() < valid_number_length) {
-        result = cleaned_invalid_number;
+    } else if (result.length() != valid_number_length) {
+        throw std::domain_error("Invalid number");
+    }
+    if (result[0] < '2' || result[3] < '2') {
+      throw std::domain_error("Invalid number");
     }
     return result;
 }

--- a/exercises/phone-number/phone_number_test.cpp
+++ b/exercises/phone-number/phone_number_test.cpp
@@ -1,54 +1,95 @@
 #include "phone_number.h"
+
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
+#include <exception>
 
-BOOST_AUTO_TEST_CASE(cleans_parens_dashes_and_spaces_from_the_number)
-{
-    const phone_number phone("(123) 456-7890");
-
-    BOOST_REQUIRE_EQUAL("1234567890", phone.number());
+BOOST_AUTO_TEST_CASE(cleans_the_number) {
+  BOOST_REQUIRE_EQUAL("2234567890", phone_number("(223) 456-7890").number());
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-BOOST_AUTO_TEST_CASE(cleans_numbers_with_dots)
-{
-    const phone_number phone("123.456.7890");
 
-    BOOST_REQUIRE_EQUAL("1234567890", phone.number());
+BOOST_AUTO_TEST_CASE(cleans_numbers_with_dots) {
+  BOOST_REQUIRE_EQUAL("2234567890", phone_number("223.456.7890").number());
 }
 
-BOOST_AUTO_TEST_CASE(valid_when_11_digits_and_first_digit_is_1)
-{
-    const phone_number phone("11234567890");
-
-    BOOST_REQUIRE_EQUAL("1234567890", phone.number());
+BOOST_AUTO_TEST_CASE(cleans_numbers_with_spaces) {
+  BOOST_REQUIRE_EQUAL("2234567890", phone_number("223 456   7890   ").number());
 }
 
-BOOST_AUTO_TEST_CASE(invalid_when_11_digits)
-{
-    const phone_number phone("21234567890");
-
-    BOOST_REQUIRE_EQUAL("0000000000", phone.number());
+BOOST_AUTO_TEST_CASE(has_an_area_code) {
+  BOOST_REQUIRE_EQUAL("223", phone_number("+1 (223) 456-7890").area_code());
 }
 
-BOOST_AUTO_TEST_CASE(invalid_when_9_digits)
-{
-    const phone_number phone("123456789");
-
-    BOOST_REQUIRE_EQUAL("0000000000", phone.number());
+BOOST_AUTO_TEST_CASE(formats_a_number) {
+  const phone_number phone("+1 (223) 456-7890");
+  BOOST_REQUIRE_EQUAL("(223) 456-7890", std::string(phone));
 }
 
-BOOST_AUTO_TEST_CASE(has_an_area_code)
-{
-    const phone_number phone("1234567890");
-
-    BOOST_REQUIRE_EQUAL("123", phone.area_code());
+BOOST_AUTO_TEST_CASE(invalid_when_9_digits) {
+  BOOST_REQUIRE_THROW(phone_number("123456789"), std::domain_error);
 }
 
-BOOST_AUTO_TEST_CASE(formats_a_number)
-{
-    const phone_number phone("1234567890");
-
-    BOOST_REQUIRE_EQUAL("(123) 456-7890", std::string(phone));
+BOOST_AUTO_TEST_CASE(invalid_when_11_digits_does_not_start_with_a_1) {
+  BOOST_REQUIRE_THROW(phone_number("22234567890"), std::domain_error);
 }
+
+BOOST_AUTO_TEST_CASE(valid_when_11_digits_and_starting_with_1) {
+  BOOST_REQUIRE_EQUAL("2234567890", phone_number("12234567890").number());
+}
+
+BOOST_AUTO_TEST_CASE(
+    valid_when_11_digits_and_starting_with_1_even_with_punctuation) {
+  BOOST_REQUIRE_EQUAL("2234567890", phone_number("+1 (223) 456-7890").number());
+}
+
+BOOST_AUTO_TEST_CASE(invalid_when_more_than_11_digits) {
+  BOOST_REQUIRE_THROW(phone_number("321234567890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_with_letters) {
+  BOOST_REQUIRE_THROW(phone_number("123-abc-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_with_punctuation) {
+  BOOST_REQUIRE_THROW(phone_number("123-@:!-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_if_area_code_starts_with_0) {
+  BOOST_REQUIRE_THROW(phone_number("(023) 456-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_if_area_code_starts_with_1) {
+  BOOST_REQUIRE_THROW(phone_number("(123) 456-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_if_exchange_code_starts_with_0) {
+  BOOST_REQUIRE_THROW(phone_number("(223) 056-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_if_exchange_code_starts_with_1) {
+  BOOST_REQUIRE_THROW(phone_number("(223) 156-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(
+    invalid_if_area_code_starts_with_0_on_valid_11_digit_number) {
+  BOOST_REQUIRE_THROW(phone_number("1 (023) 456-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(
+    invalid_if_area_code_starts_with_1_on_valid_11_digit_number) {
+  BOOST_REQUIRE_THROW(phone_number("1 (123) 456-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(
+    invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number) {
+  BOOST_REQUIRE_THROW(phone_number("1 (223) 056-7890"), std::domain_error);
+}
+
+BOOST_AUTO_TEST_CASE(
+    invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number) {
+  BOOST_REQUIRE_THROW(phone_number("1 (223) 156-7890"), std::domain_error);
+}
+
 #endif


### PR DESCRIPTION
Current examples shouldn't pass the tests since the [problem spec](https://github.com/exercism/problem-specifications/blob/master/exercises/phone-number/canonical-data.json) changed. 

EDIT: forgot to mention this is for issue #227