### PR TITLE
Updating documentation to explain Boost deprecation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ There are not many active contributors, so anyone reviewing PRs or Issues, even 
 
 ## Adding an exercise
 
+Note: We are in the process of transitioning from using the Boost test suite to
+Catch, see [#233](https://github.com/exercism/cpp/issues/233). As such, we will
+not be taking any new exercises that use the Boost test suite. Please see one
+of the exercises that use Catch for examples on how that is setup.
+
+Additionally, any exercises submitted while that work is ongoing will not be a
+priority, so may take a while to review.
+
 Here is a list of things that need to be done to add an exercise to this track.
 
 1. Add the exercise under the exercises/ directory.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -76,13 +76,17 @@ improve the CMake support.
 
 ### Prerequisite: Boost 1.59+
 
+**We are in the process of transitioning away from using Boost for most
+exercises because it is difficult to install on some platforms. You can
+follow the progress, or help, [on Github](https://github.com/exercism/cpp/issues/233).**
+
 The unit tests use Boost.Test, the unit testing framework included with
 [Boost](http://www.boost.org/index.html).  You may find other libraries
 in Boost useful to you as you work through the exercises.
 You will need to download and install Boost.  As of this writing Boost
 1.59+ is the required version.  You will need a compiled version of the
-boost libraries Boost.Test, Boost.DateTime and Boost.Regex, or you will
-need to download from source and build the library yourself.
+boost libraries Boost.Test and Boost.DateTime, or you will need to
+download from source and build the library yourself.
 
 If you are having difficulties installing Boost for use with exercism,
 [ask for help](https://github.com/exercism/cpp/issues).
@@ -166,4 +170,3 @@ If all else fails you can download the source and build it yourself,
 but you should prefer a prebuilt distribution to make things easier.
 Bootstrap instructions are on the
 [Boost getting started page](http://www.boost.org/doc/libs/release/more/getting_started/index.html).
-


### PR DESCRIPTION
Adds a small note to the installation docs explaining that some tests may not use Boost, and a link to how people can track progress. This should be merged only when there are at least a couple problems setup with Catch.

This mostly serves as a note to people having issues with installing Boost to note we are working on it. If anyone has any input about how this could be better, or would like to point out something else we should say here, please let me know.

Related to #233

