### PR TITLE
Update the test case in the leap exercise

### DIFF
--- a/exercises/leap/leap_test.cpp
+++ b/exercises/leap/leap_test.cpp
@@ -2,34 +2,34 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(a_known_leap_year)
+BOOST_AUTO_TEST_CASE(not_divisible_by_4)
+{
+    BOOST_REQUIRE(!leap::is_leap_year(2015));
+}
+
+#if defined(EXERCISM_RUN_ALL_TESTS)
+BOOST_AUTO_TEST_CASE(divisible_by_2_not_divisible_by_4)
+{
+    BOOST_REQUIRE(!leap::is_leap_year(1970));
+}
+
+BOOST_AUTO_TEST_CASE(divisible_by_4_not_divisible_by_100)
 {
     BOOST_REQUIRE(leap::is_leap_year(1996));
 }
 
-#if defined(EXERCISM_RUN_ALL_TESTS)
-BOOST_AUTO_TEST_CASE(any_old_year)
+BOOST_AUTO_TEST_CASE(divisible_by_100_not_divisible_by_400)
 {
-    BOOST_REQUIRE(!leap::is_leap_year(1997));
+    BOOST_REQUIRE(!leap::is_leap_year(2100));
 }
 
-BOOST_AUTO_TEST_CASE(turn_of_the_20th_century)
-{
-    BOOST_REQUIRE(!leap::is_leap_year(1900));
-}
-
-BOOST_AUTO_TEST_CASE(turn_of_the_21st_century)
+BOOST_AUTO_TEST_CASE(divisible_by_400)
 {
     BOOST_REQUIRE(leap::is_leap_year(2000));
 }
 
-BOOST_AUTO_TEST_CASE(turn_of_the_23th_century)
+BOOST_AUTO_TEST_CASE(divisible_by_200_not_divisible_by_400)
 {
-    BOOST_REQUIRE(!leap::is_leap_year(2200));
-}
-
-BOOST_AUTO_TEST_CASE(turn_of_the_25th_century)
-{
-    BOOST_REQUIRE(leap::is_leap_year(2400));
+    BOOST_REQUIRE(!leap::is_leap_year(1800));
 }
 #endif

--- a/exercises/leap/leap_test.cpp
+++ b/exercises/leap/leap_test.cpp
@@ -23,6 +23,11 @@ BOOST_AUTO_TEST_CASE(turn_of_the_21st_century)
     BOOST_REQUIRE(leap::is_leap_year(2000));
 }
 
+BOOST_AUTO_TEST_CASE(turn_of_the_23th_century)
+{
+    BOOST_REQUIRE(!leap::is_leap_year(2200));
+}
+
 BOOST_AUTO_TEST_CASE(turn_of_the_25th_century)
 {
     BOOST_REQUIRE(leap::is_leap_year(2400));


### PR DESCRIPTION
Since I found a student's solution was using 200 instead of 400, I think this might be a common case.

The test code we are using now is largely different from the canonical test suite. Because that code base changes quite frequently, I kept our test code, adding only one extra test case which I think is needed. Would be glad to sync the whole test code from the canonical test data if that is desired.