### PR TITLE
Adding partial builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,4 @@ install:
 script:
   - bin/fetch-configlet
   - bin/configlet lint .
-  - cmake -G Ninja
-  - ninja
+  - bin/check-exercises.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,56 +20,10 @@ endfunction()
 
 option(EXERCISM_RUN_ALL_TESTS "Run all Exercism tests" On)
 
-foreach(exercise
-    hello-world
-    bob
-    word-count
-    hamming
-    anagram
-    food-chain
-    beer-song
-    nucleotide-count
-    rna-transcription
-    phone-number
-    grade-school
-    robot-name
-    leap
-    etl
-    space-age
-    grains
-    gigasecond
-    triangle
-    clock
-    raindrops
-    difference-of-squares
-    roman-numerals
-    nth-prime
-    sieve
-    binary
-    sum-of-multiples
-    series
-    prime-factors
-    pascals-triangle
-    trinary
-    crypto-square
-    scrabble-score
-    hexadecimal
-    say
-    meetup
-    queen-attack
-    allergies
-    atbash-cipher
-    bracket-push
-    all-your-base
-    pangram
-    binary-search-tree
-    robot-simulator
-    binary-search
-    isogram
-    reverse-string
-    acronym
-    luhn
-)
+file(GLOB exercise_list ${CMAKE_CURRENT_SOURCE_DIR}/exercises/*)
+
+foreach(exercise_dir ${exercise_list})
+    get_filename_component(exercise ${exercise_dir} NAME)
     travis_fixup(${exercise} ${alt_exercise_tree})
     add_subdirectory(${alt_exercise_tree}/${exercise})
 endforeach()

--- a/bin/check-exercises.sh
+++ b/bin/check-exercises.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Runs tests only if the current Pull Request has modified a test or the root
+# CMakeLists.txt, or if we are running on the master branch.
+
+# Fail if any command fails
+set -e
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+
+# Configure all the tests.
+cmake -G Ninja "$repo"
+echo ""
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    echo "This is not a Pull Request, running all tests."
+    cmake --build "$repo"
+elif git diff --name-only master | grep "^CMakeLists.txt"; then
+    echo "This PR changes the root CMakeLists.txt."
+    echo "Running a single test and then all tests."
+    cmake --build "$repo" -- test_hello-world
+    cmake --build "$repo"
+else
+    tests="$(git diff --name-only master | grep "exercises/" | cut -d '/' -f2 | sed 's/.*/test_&/' | tr '\n' ' ')"
+    if [ ${#tests} -ne 0 ]; then
+        echo "Running only tests that have changed."
+        cmake --build "$repo" -- $tests
+    else
+        echo "No tests changed."
+    fi
+fi

--- a/bin/check-exercises.sh
+++ b/bin/check-exercises.sh
@@ -21,7 +21,7 @@ elif git diff --name-only master | grep "^CMakeLists.txt"; then
     cmake --build "$repo" -- test_hello-world
     cmake --build "$repo"
 else
-    tests="$(git diff --name-only master | grep "exercises/" | cut -d '/' -f2 | sed 's/.*/test_&/' | tr '\n' ' ')"
+    tests="$(git diff --name-only master | grep "^exercises/" | cut -d '/' -f2 | sed 's/.*/test_&/' | uniq | tr '\n' ' ')"
     if [ ${#tests} -ne 0 ]; then
         echo "Running only tests that have changed."
         cmake --build "$repo" -- $tests

--- a/exercises/acronym/acronym_test.cpp
+++ b/exercises/acronym/acronym_test.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
     const string expected{"PNG"};
 
-    BOOST_TEST(expected == actual);
+    BOOST_TEST(expected != actual);
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)

--- a/exercises/acronym/acronym_test.cpp
+++ b/exercises/acronym/acronym_test.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(basic)
 
     const string expected{"PNG"};
 
-    BOOST_TEST(expected != actual);
+    BOOST_TEST(expected == actual);
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)


### PR DESCRIPTION
This switches the Travis builds so that it tests different subsets of the exercises depending on whether it is a PR build or a branch build, and on the changes made compared to the master branch. Basically, for a normal PR this will help lighten the load while it's being worked on, and we will run a full build against master once it is merged.

Some other tracks do this already, I've borrowed from the script used for Rust but heavily modified it.

If it's a branch build we run everything, as we currently do.
If it's a PR build that changes no exercises, we run nothing.
If it's a PR build that changes 1 or more exercises, _we only run the changed exercises._
If it's a PR build that changes the _root_ CMakeLists.txt file, we run everything to make sure that works. [1]

I'll be kicking off builds on Travis to test all the paths before this is ready to be merged.

[1] - This also changes the CMakeLists.txt file so it reads the directories instead of taking in a list of exercises, so it doesn't need to be edited just to add an exercise. It'll only be changed if there are real changes to it.