### PR TITLE
Separate Catch Object

### DIFF
--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/acronym/acronym_test.cpp
+++ b/exercises/acronym/acronym_test.cpp
@@ -1,5 +1,4 @@
 #include "acronym.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/acronym/test/tests-main.cpp
+++ b/exercises/acronym/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/all-your-base/all_your_base_test.cpp
+++ b/exercises/all-your-base/all_your_base_test.cpp
@@ -1,5 +1,4 @@
 #include "all_your_base.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/all-your-base/test/tests-main.cpp
+++ b/exercises/all-your-base/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/allergies/allergies_test.cpp
+++ b/exercises/allergies/allergies_test.cpp
@@ -1,5 +1,4 @@
 #include "allergies.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 #include <string>

--- a/exercises/allergies/test/tests-main.cpp
+++ b/exercises/allergies/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/anagram/anagram_test.cpp
+++ b/exercises/anagram/anagram_test.cpp
@@ -1,5 +1,4 @@
 #include "anagram.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/anagram/test/tests-main.cpp
+++ b/exercises/anagram/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/atbash-cipher/atbash_cipher_test.cpp
+++ b/exercises/atbash-cipher/atbash_cipher_test.cpp
@@ -1,5 +1,4 @@
 #include "atbash_cipher.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("encode_yes")

--- a/exercises/atbash-cipher/test/tests-main.cpp
+++ b/exercises/atbash-cipher/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/beer-song/beer_song_test.cpp
+++ b/exercises/beer-song/beer_song_test.cpp
@@ -1,5 +1,4 @@
 #include "beer_song.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/beer-song/test/tests-main.cpp
+++ b/exercises/beer-song/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/binary-search-tree/CMakeLists.txt
+++ b/exercises/binary-search-tree/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/binary-search-tree/binary_search_tree_test.cpp
+++ b/exercises/binary-search-tree/binary_search_tree_test.cpp
@@ -1,5 +1,4 @@
 #include "binary_search_tree.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <vector>
 

--- a/exercises/binary-search-tree/test/tests-main.cpp
+++ b/exercises/binary-search-tree/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/binary-search/CMakeLists.txt
+++ b/exercises/binary-search/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/binary-search/binary_search_test.cpp
+++ b/exercises/binary-search/binary_search_test.cpp
@@ -1,5 +1,4 @@
 #include "binary_search.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <stdexcept>
 #include <vector>

--- a/exercises/binary-search/test/tests-main.cpp
+++ b/exercises/binary-search/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/binary/binary_test.cpp
+++ b/exercises/binary/binary_test.cpp
@@ -1,5 +1,4 @@
 #include "binary.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("b1_is_decimal_1")

--- a/exercises/binary/test/tests-main.cpp
+++ b/exercises/binary/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/bob/bob_test.cpp
+++ b/exercises/bob/bob_test.cpp
@@ -1,5 +1,4 @@
 #include "bob.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("stating_something")

--- a/exercises/bob/test/tests-main.cpp
+++ b/exercises/bob/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/bracket-push/CMakeLists.txt
+++ b/exercises/bracket-push/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/bracket-push/bracket_push_test.cpp
+++ b/exercises/bracket-push/bracket_push_test.cpp
@@ -1,5 +1,4 @@
 #include "bracket_push.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("paired_square_brackets")

--- a/exercises/bracket-push/test/tests-main.cpp
+++ b/exercises/bracket-push/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -1,5 +1,6 @@
 #include "clock.h"
 #include "test/catch.hpp"
+#include <sstream>
 
 using namespace std;
 

--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -1,5 +1,4 @@
 #include "clock.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/clock/test/tests-main.cpp
+++ b/exercises/clock/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/crypto-square/crypto_square_test.cpp
+++ b/exercises/crypto-square/crypto_square_test.cpp
@@ -1,5 +1,4 @@
 #include "crypto_square.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("normalize_capitals")

--- a/exercises/crypto-square/test/tests-main.cpp
+++ b/exercises/crypto-square/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/difference-of-squares/difference_of_squares_test.cpp
+++ b/exercises/difference-of-squares/difference_of_squares_test.cpp
@@ -1,5 +1,4 @@
 #include "difference_of_squares.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("up_to_5")

--- a/exercises/difference-of-squares/test/tests-main.cpp
+++ b/exercises/difference-of-squares/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/etl/etl_test.cpp
+++ b/exercises/etl/etl_test.cpp
@@ -1,5 +1,4 @@
 #include "etl.h"
-#define CATCH_CONFIG_MAIN
 #include <map>
 #include "test/catch.hpp"
 

--- a/exercises/etl/test/tests-main.cpp
+++ b/exercises/etl/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/food-chain/food_chain_test.cpp
+++ b/exercises/food-chain/food_chain_test.cpp
@@ -1,5 +1,4 @@
 #include "food_chain.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/food-chain/test/tests-main.cpp
+++ b/exercises/food-chain/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/gigasecond/gigasecond_test.cpp
+++ b/exercises/gigasecond/gigasecond_test.cpp
@@ -1,5 +1,4 @@
 #include "gigasecond.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
 

--- a/exercises/gigasecond/test/tests-main.cpp
+++ b/exercises/gigasecond/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/grade-school/grade_school_test.cpp
+++ b/exercises/grade-school/grade_school_test.cpp
@@ -1,5 +1,4 @@
 #include "grade_school.h"
-#define CATCH_CONFIG_MAIN
 #include <map>
 #include "test/catch.hpp"
 

--- a/exercises/grade-school/test/tests-main.cpp
+++ b/exercises/grade-school/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/grains/grains_test.cpp
+++ b/exercises/grains/grains_test.cpp
@@ -1,5 +1,4 @@
 #include "grains.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("square_1")

--- a/exercises/grains/test/tests-main.cpp
+++ b/exercises/grains/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/hamming/hamming_test.cpp
+++ b/exercises/hamming/hamming_test.cpp
@@ -1,6 +1,5 @@
 #include "hamming.h"
 #include <stdexcept>
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("no_difference_between_identical_strands")

--- a/exercises/hamming/test/tests-main.cpp
+++ b/exercises/hamming/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/hello-world/hello_world_test.cpp
+++ b/exercises/hello-world/hello_world_test.cpp
@@ -1,5 +1,4 @@
 #include "hello_world.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("test_hello")

--- a/exercises/hello-world/test/tests-main.cpp
+++ b/exercises/hello-world/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/hexadecimal/hexadecimal_test.cpp
+++ b/exercises/hexadecimal/hexadecimal_test.cpp
@@ -1,5 +1,4 @@
 #include "hexadecimal.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("hex_1_is_decimal_1")

--- a/exercises/hexadecimal/test/tests-main.cpp
+++ b/exercises/hexadecimal/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/isogram/isogram_test.cpp
+++ b/exercises/isogram/isogram_test.cpp
@@ -1,5 +1,4 @@
 #include "isogram.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 using namespace std;

--- a/exercises/isogram/test/tests-main.cpp
+++ b/exercises/isogram/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/leap/leap_test.cpp
+++ b/exercises/leap/leap_test.cpp
@@ -1,5 +1,4 @@
 #include "leap.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("not_divisible_by_4")

--- a/exercises/leap/test/tests-main.cpp
+++ b/exercises/leap/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/luhn/CMakeLists.txt
+++ b/exercises/luhn/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/luhn/luhn_test.cpp
+++ b/exercises/luhn/luhn_test.cpp
@@ -1,5 +1,4 @@
 #include "luhn.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 //Luhn exercise test case data version 1.5.0

--- a/exercises/luhn/test/tests-main.cpp
+++ b/exercises/luhn/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/meetup/meetup_test.cpp
+++ b/exercises/meetup/meetup_test.cpp
@@ -1,5 +1,4 @@
 #include "meetup.h"
-#define CATCH_CONFIG_MAIN
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include "test/catch.hpp"
 

--- a/exercises/meetup/test/tests-main.cpp
+++ b/exercises/meetup/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/nth-prime/nth_prime_test.cpp
+++ b/exercises/nth-prime/nth_prime_test.cpp
@@ -1,5 +1,4 @@
 #include "nth_prime.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <stdexcept>
 

--- a/exercises/nth-prime/test/tests-main.cpp
+++ b/exercises/nth-prime/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/nucleotide-count/nucleotide_count_test.cpp
@@ -1,5 +1,4 @@
 #include "nucleotide_count.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <map>
 #include <stdexcept>

--- a/exercises/nucleotide-count/test/tests-main.cpp
+++ b/exercises/nucleotide-count/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/pangram/pangram_test.cpp
+++ b/exercises/pangram/pangram_test.cpp
@@ -1,5 +1,4 @@
 #include "pangram.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("sentence_empty")

--- a/exercises/pangram/test/tests-main.cpp
+++ b/exercises/pangram/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/pascals-triangle/CMakeLists.txt
+++ b/exercises/pascals-triangle/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/pascals-triangle/pascals_triangle_test.cpp
+++ b/exercises/pascals-triangle/pascals_triangle_test.cpp
@@ -1,5 +1,4 @@
 #include "pascals_triangle.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("zero_rows")

--- a/exercises/pascals-triangle/test/tests-main.cpp
+++ b/exercises/pascals-triangle/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/phone-number/phone_number_test.cpp
+++ b/exercises/phone-number/phone_number_test.cpp
@@ -1,6 +1,5 @@
 #include "phone_number.h"
 
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <exception>
 

--- a/exercises/phone-number/test/tests-main.cpp
+++ b/exercises/phone-number/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/prime-factors/prime_factors_test.cpp
+++ b/exercises/prime-factors/prime_factors_test.cpp
@@ -1,5 +1,4 @@
 #include "prime_factors.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("_1_yields_empty")

--- a/exercises/prime-factors/test/tests-main.cpp
+++ b/exercises/prime-factors/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/queen-attack/queen_attack_test.cpp
+++ b/exercises/queen-attack/queen_attack_test.cpp
@@ -1,5 +1,4 @@
 #include "queen_attack.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("queens_in_default_positions")

--- a/exercises/queen-attack/test/tests-main.cpp
+++ b/exercises/queen-attack/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/raindrops/raindrops_test.cpp
+++ b/exercises/raindrops/raindrops_test.cpp
@@ -1,5 +1,4 @@
 #include "raindrops.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("one_yields_itself")

--- a/exercises/raindrops/test/tests-main.cpp
+++ b/exercises/raindrops/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/reverse-string/reverse_string_test.cpp
+++ b/exercises/reverse-string/reverse_string_test.cpp
@@ -1,5 +1,4 @@
 #include "reverse_string.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("an_empty_string")

--- a/exercises/reverse-string/test/tests-main.cpp
+++ b/exercises/reverse-string/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/rna-transcription/rna_transcription_test.cpp
+++ b/exercises/rna-transcription/rna_transcription_test.cpp
@@ -1,5 +1,4 @@
 #include "rna_transcription.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("transcribes_cytidine_to_guanosine")

--- a/exercises/rna-transcription/test/tests-main.cpp
+++ b/exercises/rna-transcription/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/robot-name/robot_name_test.cpp
+++ b/exercises/robot-name/robot_name_test.cpp
@@ -1,5 +1,4 @@
 #include "robot_name.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <cctype>
 #include <string>

--- a/exercises/robot-name/test/tests-main.cpp
+++ b/exercises/robot-name/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/robot-simulator/CMakeLists.txt
+++ b/exercises/robot-simulator/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/robot-simulator/robot_simulator_test.cpp
+++ b/exercises/robot-simulator/robot_simulator_test.cpp
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include "robot_simulator.h"
 

--- a/exercises/robot-simulator/test/tests-main.cpp
+++ b/exercises/robot-simulator/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/roman-numerals/roman_numerals_test.cpp
@@ -1,5 +1,4 @@
 #include "roman_numerals.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("one_yields_I")

--- a/exercises/roman-numerals/test/tests-main.cpp
+++ b/exercises/roman-numerals/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/say/say_test.cpp
+++ b/exercises/say/say_test.cpp
@@ -1,5 +1,4 @@
 #include "say.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("zero")

--- a/exercises/say/test/tests-main.cpp
+++ b/exercises/say/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/scrabble-score/scrabble_score_test.cpp
+++ b/exercises/scrabble-score/scrabble_score_test.cpp
@@ -1,5 +1,4 @@
 #include "scrabble_score.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("scores_an_empty_word_as_zero")

--- a/exercises/scrabble-score/test/tests-main.cpp
+++ b/exercises/scrabble-score/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/series/series_test.cpp
+++ b/exercises/series/series_test.cpp
@@ -1,5 +1,4 @@
 #include "series.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <stdexcept>
 

--- a/exercises/series/test/tests-main.cpp
+++ b/exercises/series/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/sieve/sieve_test.cpp
+++ b/exercises/sieve/sieve_test.cpp
@@ -1,5 +1,4 @@
 #include "sieve.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("no_primes_under_two")

--- a/exercises/sieve/test/tests-main.cpp
+++ b/exercises/sieve/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/space-age/space_age_test.cpp
+++ b/exercises/space-age/space_age_test.cpp
@@ -1,5 +1,4 @@
 #include "space_age.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("age_in_seconds")

--- a/exercises/space-age/test/tests-main.cpp
+++ b/exercises/space-age/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/sum-of-multiples/sum_of_multiples_test.cpp
+++ b/exercises/sum-of-multiples/sum_of_multiples_test.cpp
@@ -1,5 +1,4 @@
 #include "sum_of_multiples.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("sum_to_1_yields_0")

--- a/exercises/sum-of-multiples/test/tests-main.cpp
+++ b/exercises/sum-of-multiples/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/triangle/test/tests-main.cpp
+++ b/exercises/triangle/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/triangle/triangle_test.cpp
+++ b/exercises/triangle/triangle_test.cpp
@@ -1,5 +1,4 @@
 #include "triangle.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <stdexcept>
 

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/trinary/test/tests-main.cpp
+++ b/exercises/trinary/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/trinary/trinary_test.cpp
+++ b/exercises/trinary/trinary_test.cpp
@@ -1,5 +1,4 @@
 #include "trinary.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 
 TEST_CASE("_1_yields_decimal_1")

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 
 set_target_properties(${exercise} PROPERTIES
     CXX_STANDARD 11

--- a/exercises/word-count/test/tests-main.cpp
+++ b/exercises/word-count/test/tests-main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/exercises/word-count/word_count_test.cpp
+++ b/exercises/word-count/word_count_test.cpp
@@ -1,5 +1,4 @@
 #include "word_count.h"
-#define CATCH_CONFIG_MAIN
 #include "test/catch.hpp"
 #include <map>
 


### PR DESCRIPTION
This adds a separate compilation object for the Catch main configuration. See https://github.com/catchorg/Catch2/blob/master/docs/slow-compiles.md for an explanation from Catch.

In short, including the Catch header is relatively heavy but not too bad, but most of the compilation time for Catch comes from compiling it with support for main, as that actually causes a compile of the Catch functionality and not just of the interface. By separating this out into it's own object, we ensure that students only need to build the object once per exercise, rather than every time they modify the test.cpp file or their exercise header. This was discussed in the comments of #233.

This also revealed an issue of a missing include in the clock test, which is fixed here.

This was done with the following script:

```fish
cd exercises/
ls */*_test.cpp | xargs sed -i '/CATCH_CONFIG_MAIN/d'
ls */CMakeLists.txt | xargs sed -i 's/${file}.h/${file}.h\ test\/tests-main.cpp)/'
for x in *
  echo "#define CATCH_CONFIG_MAIN" >> $x/test/tests-main.cpp
  echo "#include \"catch.hpp\"" >> $x/test/tests-main.cpp
end
```