### PR TITLE
Fixes #280. Problem spec intact.

### DIFF
--- a/exercises/all-your-base/all_your_base_test.cpp
+++ b/exercises/all-your-base/all_your_base_test.cpp
@@ -3,15 +3,8 @@
 
 using namespace std;
 
-TEST_CASE("test1") {
-    vector<unsigned int> in_digits{0};
-    vector<unsigned int> out_digits = all_your_base::convert(10, in_digits, 2);
-    vector<unsigned int> expected{};
+//all-your-base exercise test case data version 2.3.0
 
-    REQUIRE(expected == out_digits);
-}
-
-#if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("single_bit_one_to_decimal") {
     vector<unsigned int> in_digits{1};
     vector<unsigned int> expected{1};
@@ -20,6 +13,7 @@ TEST_CASE("single_bit_one_to_decimal") {
     REQUIRE(expected == out_digits);
 }
 
+#if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("binary_to_single_decimal") {
     vector<unsigned int> in_digits{1, 0, 1};
     vector<unsigned int> expected{5};
@@ -110,26 +104,31 @@ TEST_CASE("leading_zeros") {
 
 TEST_CASE("first_base_is_one") {
     vector<unsigned int> in_digits{};
+
     REQUIRE_THROWS_AS(all_your_base::convert(1, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("first_base_is_zero") {
     vector<unsigned int> in_digits{};
+
     REQUIRE_THROWS_AS(all_your_base::convert(0, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("invalid_positive_digit") {
     vector<unsigned int> in_digits{1, 2, 1, 0, 1, 0};
+
     REQUIRE_THROWS_AS(all_your_base::convert(2, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("second_base_is_one") {
     vector<unsigned int> in_digits{1, 0, 1, 0, 1, 0};
+
     REQUIRE_THROWS_AS(all_your_base::convert(2, in_digits, 1), std::invalid_argument);
 }
 
 TEST_CASE("second_base_is_zero") {
     vector<unsigned int> in_digits{7};
+
     REQUIRE_THROWS_AS(all_your_base::convert(10, in_digits, 0), std::invalid_argument);
 }
 

--- a/exercises/all-your-base/all_your_base_test.cpp
+++ b/exercises/all-your-base/all_your_base_test.cpp
@@ -102,7 +102,7 @@ TEST_CASE("multiple_zeros") {
 
 TEST_CASE("leading_zeros") {
     vector<unsigned int> in_digits{0, 6, 0};
-    vector<unsigned int> expected{};
+    vector<unsigned int> expected{4, 2};
     vector<unsigned int> out_digits = all_your_base::convert(7, in_digits, 10);
 
     REQUIRE(expected == out_digits);
@@ -110,42 +110,27 @@ TEST_CASE("leading_zeros") {
 
 TEST_CASE("first_base_is_one") {
     vector<unsigned int> in_digits{};
-    vector<unsigned int> expected{};
-    vector<unsigned int> out_digits = all_your_base::convert(1, in_digits, 10);
-
-    REQUIRE(expected == out_digits);
+    REQUIRE_THROWS_AS(all_your_base::convert(1, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("first_base_is_zero") {
     vector<unsigned int> in_digits{};
-    vector<unsigned int> expected{};
-    vector<unsigned int> out_digits = all_your_base::convert(0, in_digits, 10);
-
-    REQUIRE(expected == out_digits);
+    REQUIRE_THROWS_AS(all_your_base::convert(0, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("invalid_positive_digit") {
     vector<unsigned int> in_digits{1, 2, 1, 0, 1, 0};
-    vector<unsigned int> expected{};
-    vector<unsigned int> out_digits = all_your_base::convert(2, in_digits, 10);
-
-    REQUIRE(expected == out_digits);
+    REQUIRE_THROWS_AS(all_your_base::convert(2, in_digits, 10), std::invalid_argument);
 }
 
 TEST_CASE("second_base_is_one") {
     vector<unsigned int> in_digits{1, 0, 1, 0, 1, 0};
-    vector<unsigned int> expected{};
-    vector<unsigned int> out_digits = all_your_base::convert(2, in_digits, 1);
-
-    REQUIRE(expected == out_digits);
+    REQUIRE_THROWS_AS(all_your_base::convert(2, in_digits, 1), std::invalid_argument);
 }
 
 TEST_CASE("second_base_is_zero") {
     vector<unsigned int> in_digits{7};
-    vector<unsigned int> expected{};
-    vector<unsigned int> out_digits = all_your_base::convert(10, in_digits, 0);
-
-    REQUIRE(expected == out_digits);
+    REQUIRE_THROWS_AS(all_your_base::convert(10, in_digits, 0), std::invalid_argument);
 }
 
 #endif

--- a/exercises/all-your-base/example.cpp
+++ b/exercises/all-your-base/example.cpp
@@ -1,5 +1,6 @@
 #include "all_your_base.h"
 #include <vector>
+#include <stdexcept>
 
 namespace all_your_base {
 
@@ -8,15 +9,13 @@ std::vector<unsigned int> convert(unsigned int input_base,
                                   unsigned int output_base) {
     std::vector<unsigned int> b;
     unsigned int value = 0;
+    if (input_base <= 1 || output_base <= 1)
+        throw std::invalid_argument("Invalid base");
     if (input_digits.empty())
-        return {};
-    if (!input_digits.empty() && input_digits.front() == 0)
-        return {};
-    if (input_base == 0 || output_base <= 1)
         return {};
     for (unsigned int d : input_digits) {
         if (d >= input_base)
-            return {};
+            throw std::invalid_argument("Invalid number");
         value = value * input_base + d;
     }
     while (value != 0) {


### PR DESCRIPTION
Fixes #280 without modifying base 1 behavior. Fixes `leading_zeros` test case and requires `std::error` for test cases where the base is invalid.