### PR TITLE
Update to C++14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
-            - libc++-dev
+            - g++-5
 
     - env:
       - COMPILER=clang++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,22 @@ os: linux
 
 matrix:
   include:
-    - env: COMPILER=g++-7
+    - env: COMPILER=g++-5
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-5
 
-    - env: COMPILER=clang++-6.0
+    - env: COMPILER=clang++-3.8
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-precise-3.8
           packages:
-            - clang-6.0
+            - clang-3.8
 
     - env:
       - COMPILER=clang++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
+            - libc++-dev
 
     - env:
       - COMPILER=clang++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,22 @@ os: linux
 
 matrix:
   include:
-    - env: COMPILER=g++-4.9
+    - env: COMPILER=g++-7
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
+            - g++-7
 
-    - env: COMPILER=clang++-3.8
+    - env: COMPILER=clang++-6.0
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
+            - llvm-toolchain-precise-6
           packages:
-            - clang-3.8
+            - clang-6
 
     - env:
       - COMPILER=clang++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-6
+            - llvm-toolchain-trusty-6.0
           packages:
-            - clang-6
+            - clang-6.0
 
     - env:
       - COMPILER=clang++-7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 project(exercism CXX)
 
 set(alt_exercise_tree ${CMAKE_CURRENT_SOURCE_DIR}/build_exercises)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -13,14 +13,14 @@ issues setting it up you will find many helpful resources online.
 
 Many IDE's, including Microsoft's Visual Studio, Apple's Xcode, and JetBrains'
 CLion bundle a compiler and CMake together, so you should only need to install
-the IDE. 
+the IDE.
 
 ### A Modern C++14 Compiler
 
 This language track requires a compiler with [C++14](http://en.wikipedia.org/wiki/C%2B%2B14)
 support, which was released in 2014. All major compilers released in the last few years should
 be compatible, so as long as you are on a fairly recent version you should be fine.
-Specifically, GCC version 7 or later, Clang version 6 or later, or Visual
+Specifically, GCC version 5 or later, Clang version 3.8 or later, or Visual
 Studio 2017 or later.
 
 ### CMake
@@ -45,7 +45,7 @@ systems.  If you encounter any problems with the supplied CMake recipe,
 please [report the issue](https://github.com/exercism/cpp/issues) so we can
 improve the CMake support.
 
-[CMake 3.1.3 or later](http://www.cmake.org/) is required to use the provided build recipe.
+[CMake 3.5.1 or later](http://www.cmake.org/) is required to use the provided build recipe.
 
 ## Windows
 
@@ -65,7 +65,8 @@ You should be able to use other integrated IDE's such as JetBrains' CLion in a s
 ## Linux
 
 All recent Linux distribution releases have compatible C++14 compilers, you
-should be able to install it using your package manager.
+should be able to install it using your package manager. The versions we support
+are the default installed versions in Ubuntu LTS 16.04.
 
 For example, on Ubuntu you would use the following command to install gcc.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -2,7 +2,7 @@
 
 The C++ language track requires that you have the following software
 installed on your system:
-* a modern C++11 compiler
+* a modern C++14 compiler
 * the CMake cross-platform build system
 
 We use [Catch2](https://github.com/catchorg/Catch2) for testing, which is a
@@ -15,13 +15,13 @@ Many IDE's, including Microsoft's Visual Studio, Apple's Xcode, and JetBrains'
 CLion bundle a compiler and CMake together, so you should only need to install
 the IDE. 
 
-### A Modern C++11 Compiler
+### A Modern C++14 Compiler
 
-This language track requires a compiler with [C++11](http://en.wikipedia.org/wiki/C%2B%2B11)
-support, which was released in 2011. All major compilers released in the last few years should
+This language track requires a compiler with [C++14](http://en.wikipedia.org/wiki/C%2B%2B14)
+support, which was released in 2014. All major compilers released in the last few years should
 be compatible, so as long as you are on a fairly recent version you should be fine.
-Specifically, GCC version 5.1 or later, Clang version 3.8 or later, or Visual
-Studio 2015 or later.
+Specifically, GCC version 7 or later, Clang version 6 or later, or Visual
+Studio 2017 or later.
 
 ### CMake
 
@@ -64,7 +64,7 @@ You should be able to use other integrated IDE's such as JetBrains' CLion in a s
 
 ## Linux
 
-All recent Linux distribution releases have compatible C++11 compilers, you
+All recent Linux distribution releases have compatible C++14 compilers, you
 should be able to install it using your package manager.
 
 For example, on Ubuntu you would use the following command to install gcc.
@@ -75,18 +75,8 @@ $ gcc --version
 ```
 
 If you are on an older distribution, you might not have a compiler that
-supports C++11. In that case you will need to install it through an alternate
-method. For example, Ubuntu 15.10 or earlier don't provide compatible compilers
-in the package manager, so if you are using that version you will need to use
-the following:
-
-```bash
-$ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-$ sudo apt-get -qq -d update
-$ sudo apt-get -qq install g++-5
-$ # make g++ 5 the default g++ executable
-$ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
-```
+supports C++14. If that's the case, you'll need to work with your distribution
+to figure out how to install the minimum compiler version.
 
 ## MacOS
 

--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/allergies/allergies_test.cpp
+++ b/exercises/allergies/allergies_test.cpp
@@ -82,7 +82,7 @@ TEST_CASE("allergic_to_eggs_and_other_stuff")
 TEST_CASE("allergic_to_nothing")
 {
     allergies::allergy_test score(0);
-    const std::unordered_set<std::string> no_allergies;
+    const std::unordered_set<std::string> no_allergies{};
 
     REQUIRE(no_allergies == score.get_allergies());
 }

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/armstrong-numbers/CMakeLists.txt
+++ b/exercises/armstrong-numbers/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/armstrong-numbers/CMakeLists.txt
+++ b/exercises/armstrong-numbers/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/binary-search-tree/CMakeLists.txt
+++ b/exercises/binary-search-tree/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/binary-search-tree/CMakeLists.txt
+++ b/exercises/binary-search-tree/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/binary-search/CMakeLists.txt
+++ b/exercises/binary-search/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/binary-search/CMakeLists.txt
+++ b/exercises/binary-search/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/luhn/CMakeLists.txt
+++ b/exercises/luhn/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/luhn/CMakeLists.txt
+++ b/exercises/luhn/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/matching-brackets/CMakeLists.txt
+++ b/exercises/matching-brackets/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/matching-brackets/CMakeLists.txt
+++ b/exercises/matching-brackets/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/pascals-triangle/CMakeLists.txt
+++ b/exercises/pascals-triangle/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/pascals-triangle/CMakeLists.txt
+++ b/exercises/pascals-triangle/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/robot-simulator/CMakeLists.txt
+++ b/exercises/robot-simulator/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/robot-simulator/CMakeLists.txt
+++ b/exercises/robot-simulator/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )


### PR DESCRIPTION
Closes #189 

This change updates CMakeLists.txt files, Travis CI, and the docs so that the track requires C++14 instead of C++11. As much as I would like to just jump to C++17, it's better to support students that are running older OSes. The students doing that are often the same students that would have trouble installing a newer compiler outside of their OS's standard installation methods.

As I explained in a comment in #189, it makes sense to do this now since even the latest Ubuntu LTS version (18.04 bionic) has a default compiler that supports C++14. The new required minimum compiler versions are what ships with that version (clang 6 and gcc 7).