### PR TITLE
Circular buffer - add test case for initial clear

### DIFF
--- a/exercises/circular-buffer/circular_buffer_test.cpp
+++ b/exercises/circular-buffer/circular_buffer_test.cpp
@@ -2,7 +2,7 @@
 #include "circular_buffer.h"
 #include <stdexcept>
 
-// Circular-buffer exercise test case data version 1.1.0
+// Circular-buffer exercise test case data version 1.2.0
 
 TEST_CASE("reading_empty_buffer_should_fail") 
 {
@@ -218,5 +218,26 @@ TEST_CASE("check_correctness_with_string_type")
 
     expected = "banana";
     REQUIRE(expected == buffer.read());
+}
+
+TEST_CASE("initial_clear_does_not_affect_wrapping_around")
+{
+    circular_buffer::circular_buffer<int> buffer(2);
+
+    buffer.clear();
+
+    REQUIRE_NOTHROW(buffer.write(1));
+    REQUIRE_NOTHROW(buffer.write(2));
+
+    buffer.overwrite(3);
+    buffer.overwrite(4);
+
+    int expected = 3;
+    REQUIRE(expected == buffer.read());
+
+    expected = 4;
+    REQUIRE(expected == buffer.read());
+
+    REQUIRE_THROWS_AS(buffer.read(), std::domain_error);
 }
 #endif  // !EXERCISM_RUN_ALL_TESTS


### PR DESCRIPTION
This adds a test case to Circular buffer, testing for a quite specific but important case when `circular_buffer::clear()` partially affects the use of the buffer.

In the solution where I came across this, the underlying `vector` was being `clear()`ed as well, preserving the allocated space while messing with the start and end iterators. This passed all the tests, however, as there was no test for `clear()` followed by `overwrite()` nor a failing `read()`.

[Link to the solution](https://exercism.io/mentor/solutions/dabad4b50b764378afb4e2cf976e584d?iteration_idx=2)