### PR TITLE
Anagram - modify test cases

### DIFF
--- a/exercises/anagram/anagram_test.cpp
+++ b/exercises/anagram/anagram_test.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-// Anagram exercise test case data version 1.4.0
+// Anagram exercise test case data version 1.5.0
 
 TEST_CASE("no_matches")
 {
@@ -55,6 +55,15 @@ TEST_CASE("detects_three_anagrams")
         "leading"
     });
     vector<string> expected{"gallery", "regally", "largely"};
+
+    REQUIRE(expected == matches);
+}
+
+TEST_CASE("detects_multiple_anagrams_with_different_case")
+{
+    auto subject = anagram::anagram("nose");
+    auto matches = subject.matches({"Eons", "ONES"});
+    vector<string> expected{"Eons", "ONES"};
 
     REQUIRE(expected == matches);
 }
@@ -118,6 +127,15 @@ TEST_CASE("words_are_not_anagrams_of_themselves_case_insensitive")
     auto subject = anagram::anagram("BANANA");
     auto matches = subject.matches({"BANANA", "Banana", "banana"});
     vector<string> expected;
+
+    REQUIRE(expected == matches);
+}
+
+TEST_CASE("words_other_than_themselves_can_be_anagrams")
+{
+    auto subject = anagram::anagram("LISTEN");
+    auto matches = subject.matches({"Listen", "Silent", "LISTEN"});
+    vector<string> expected{"Silent"};
 
     REQUIRE(expected == matches);
 }


### PR DESCRIPTION
This should no longer allow weird solutions where the entire input is rejected if some of the anagram / original word input strings have different case to pass.

Original solution where this was noted: https://exercism.io/mentor/solutions/e4f49b89e76042c9b82544bcfca04929