### PR TITLE
Word-count - update tests specification to version 1.4.0

### DIFF
--- a/exercises/word-count/word_count_test.cpp
+++ b/exercises/word-count/word_count_test.cpp
@@ -4,6 +4,8 @@
 
 using namespace std;
 
+// Word-count exercise test case data version 1.4.0
+
 TEST_CASE("counts_one_word")
 {
     const map<string, int> expected{{"word", 1}};
@@ -32,11 +34,27 @@ TEST_CASE("counts_multiple_occurrences")
     REQUIRE(expected == actual);
 }
 
+TEST_CASE("handles_cramped_list")
+{
+    const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
+    const auto actual = word_count::words("one,two,three");
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("handles_expanded_list")
+{
+    const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
+    const auto actual = word_count::words("one,\ntwo,\nthree");
+
+    REQUIRE(expected == actual);
+}
+
 TEST_CASE("ignores_punctuation")
 {
     const map<string, int> expected{{"car", 1}, {"carpet", 1}, {"as", 1}, {"java", 1}, {"javascript", 1}};
 
-    const auto actual = word_count::words("car : carpet as java : javascript!!&@$%^&");
+    const auto actual = word_count::words("car: carpet as java: javascript!!&@$%^&");
 
     REQUIRE(expected == actual);
 }
@@ -52,43 +70,9 @@ TEST_CASE("includes_numbers")
 
 TEST_CASE("normalizes_case")
 {
-    const map<string, int> expected{{"go", 3}};
+    const map<string, int> expected{{"go", 3}, {"stop", 2}};
 
-    const auto actual = word_count::words("go Go GO");
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("counts_constructor")
-{
-    const map<string, int> expected{{"constructor", 2}};
-
-    const auto actual = word_count::words("constructor Constructor");
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("counts_multiline")
-{
-    const map<string, int> expected{{"hello", 1}, {"world", 1}};
-
-    const auto actual = word_count::words("hello\nworld");
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("count_everything_just_once")
-{
-    const map<string, int> expected{{"all", 2}, {"the", 2}, {"kings", 2}, {"horses", 1}, {"and", 1}, {"men", 1}};
-    const auto actual = word_count::words("all the kings horses and all the kings men");
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("handles_cramped_list")
-{
-    const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
-    const auto actual = word_count::words("one,two,three");
+    const auto actual = word_count::words("go Go GO Stop stop");
 
     REQUIRE(expected == actual);
 }
@@ -101,18 +85,10 @@ TEST_CASE("with_apostrophes")
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("with_free_standing_apostrophes")
+TEST_CASE("with_quotations")
 {
-    const map<string, int> expected{{ "go", 3 }};
-    const auto actual = word_count::words("go ' Go '' GO");
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("with_apostrophes_as_quotes")
-{
-    const map<string, int> expected{{"she", 1}, {"said", 1}, {"let's", 1}, {"meet", 1}, {"at", 1}, {"twelve", 1}, {"o'clock", 1}};
-    const auto actual = word_count::words("She said, 'let's meet at twelve o'clock'");
+    const map<string, int> expected{{"joe", 1}, {"can't", 1}, {"tell", 1}, {"between", 1}, {"large", 2}, {"and", 1}};
+    const auto actual = word_count::words("Joe can't tell between 'large' and large.");
 
     REQUIRE(expected == actual);
 }

--- a/exercises/word-count/word_count_test.cpp
+++ b/exercises/word-count/word_count_test.cpp
@@ -116,4 +116,29 @@ TEST_CASE("with_apostrophes_as_quotes")
 
     REQUIRE(expected == actual);
 }
+
+TEST_CASE("substrings_from_the_beginning")
+{
+    const map<string, int> expected{{ "joe", 1 }, { "can't", 1 }, { "tell", 1 }, { "between", 1 }, { "app", 1 }, { "apple", 1 }, { "and", 1 }, { "a", 1 }};
+    const auto actual = word_count::words("Joe can't tell between app, apple and a.");
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("multiple_spaces_not_detected_as_a_word")
+{
+    const map<string, int> expected{{ "multiple", 1 }, { "whitespaces", 1 }};
+    const auto actual = word_count::words(" multiple   whitespaces");
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("alternating_word_separators_not_detected_as_a_word")
+{
+    const map<string, int> expected{{ "one", 1 }, { "two", 1 }, { "three", 1 }};
+    const auto actual = word_count::words(",\n,one,\n ,two \n 'three'");
+
+    REQUIRE(expected == actual);
+}
+
 #endif

--- a/exercises/word-count/word_count_test.cpp
+++ b/exercises/word-count/word_count_test.cpp
@@ -37,6 +37,7 @@ TEST_CASE("counts_multiple_occurrences")
 TEST_CASE("handles_cramped_list")
 {
     const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
+
     const auto actual = word_count::words("one,two,three");
 
     REQUIRE(expected == actual);
@@ -45,6 +46,7 @@ TEST_CASE("handles_cramped_list")
 TEST_CASE("handles_expanded_list")
 {
     const map<string, int> expected{{"one", 1}, {"two", 1}, {"three", 1}};
+
     const auto actual = word_count::words("one,\ntwo,\nthree");
 
     REQUIRE(expected == actual);
@@ -80,6 +82,7 @@ TEST_CASE("normalizes_case")
 TEST_CASE("with_apostrophes")
 {
     const map<string, int> expected{{"first", 1}, {"don't", 2}, {"laugh", 1}, {"then", 1}, {"cry", 1}};
+
     const auto actual = word_count::words("First: don't laugh. Then: don't cry.");
 
     REQUIRE(expected == actual);
@@ -88,6 +91,7 @@ TEST_CASE("with_apostrophes")
 TEST_CASE("with_quotations")
 {
     const map<string, int> expected{{"joe", 1}, {"can't", 1}, {"tell", 1}, {"between", 1}, {"large", 2}, {"and", 1}};
+
     const auto actual = word_count::words("Joe can't tell between 'large' and large.");
 
     REQUIRE(expected == actual);
@@ -96,6 +100,7 @@ TEST_CASE("with_quotations")
 TEST_CASE("substrings_from_the_beginning")
 {
     const map<string, int> expected{{ "joe", 1 }, { "can't", 1 }, { "tell", 1 }, { "between", 1 }, { "app", 1 }, { "apple", 1 }, { "and", 1 }, { "a", 1 }};
+
     const auto actual = word_count::words("Joe can't tell between app, apple and a.");
 
     REQUIRE(expected == actual);
@@ -104,6 +109,7 @@ TEST_CASE("substrings_from_the_beginning")
 TEST_CASE("multiple_spaces_not_detected_as_a_word")
 {
     const map<string, int> expected{{ "multiple", 1 }, { "whitespaces", 1 }};
+
     const auto actual = word_count::words(" multiple   whitespaces");
 
     REQUIRE(expected == actual);
@@ -112,6 +118,7 @@ TEST_CASE("multiple_spaces_not_detected_as_a_word")
 TEST_CASE("alternating_word_separators_not_detected_as_a_word")
 {
     const map<string, int> expected{{ "one", 1 }, { "two", 1 }, { "three", 1 }};
+
     const auto actual = word_count::words(",\n,one,\n ,two \n 'three'");
 
     REQUIRE(expected == actual);


### PR DESCRIPTION
Adds three test cases:

* substrings_from_the_beginning (exercism/problem-specifications#1557)
* multiple_spaces_not_detected_as_a_word (exercism/problem-specifications#1023)
* alternating_word_separators_not_detected_as_a_word (exercism/problem-specifications#1446)