### PR TITLE
Add File Stubs

### DIFF
--- a/bin/make-stub-files.sh
+++ b/bin/make-stub-files.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Helper script to fix up incorrect namespaces and add stub files.
+
+exercises_dir=$(cd "$(dirname "$0")/../exercises" && pwd)
+
+for exercise_dir in "${exercises_dir}"/*; do
+    cd "$exercise_dir" || exit 1
+    exercise_name=$(basename "$(pwd)" | sed 's/-/_/g')
+    # Rename incorrect namespaces
+    if ! grep -q "namespace $exercise_name" ./*.cpp ./*.h; then
+        echo "Cleaning up $exercise_name"
+        old=$(grep '^namespace [[:lower:]_]*' *.h --no-filename --max-count 1 --only-matching | head -1 | cut -d ' ' -f2)
+        find . -name "*.h" -exec sed -i "s/namespace $old/namespace $exercise_name/g" {} \;
+        find . -name "*.cpp" -exec sed -i "s/namespace $old/namespace $exercise_name/g" {} \;
+        find . -name "*.h" -exec sed -i "s/$old::/$exercise_name::/g" {} \;
+        find . -name "*.cpp" -exec sed -i "s/$old::/$exercise_name::/g" {} \;
+        git commit * -m "$exercise_name: Fix-up namespace"
+    fi
+    # Add stubs if they don't exist
+    header="$exercise_name.h"
+    source="$exercise_name.cpp"
+    if ! test -f "$header"; then
+        printf "#if !defined(${exercise_name^^}_H)\n" >> $header
+        printf "#define ${exercise_name^^}_H\n" >> $header
+        printf "\nnamespace $exercise_name {\n\n}  // namespace $exercise_name\n" >> $header
+        printf "\n#endif // ${exercise_name^^}_H" >> $header
+        git add $header
+    fi
+    if ! test -f "$source"; then
+        printf "#include \"$header\"\n" >> $source
+        printf "\nnamespace $exercise_name {\n\n}  // namespace $exercise_name\n" >> $source
+        git add $source
+    fi
+done

--- a/exercises/acronym/acronym.cpp
+++ b/exercises/acronym/acronym.cpp
@@ -1,0 +1,5 @@
+#include "acronym.h"
+
+namespace acronym {
+
+}  // namespace acronym

--- a/exercises/acronym/acronym.h
+++ b/exercises/acronym/acronym.h
@@ -1,0 +1,8 @@
+#if !defined(ACRONYM_H)
+#define ACRONYM_H
+
+namespace acronym {
+
+}  // namespace acronym
+
+#endif // ACRONYM_H

--- a/exercises/all-your-base/all_your_base.cpp
+++ b/exercises/all-your-base/all_your_base.cpp
@@ -1,0 +1,5 @@
+#include "all_your_base.h"
+
+namespace all_your_base {
+
+}  // namespace all_your_base

--- a/exercises/all-your-base/all_your_base.h
+++ b/exercises/all-your-base/all_your_base.h
@@ -1,0 +1,8 @@
+#if !defined(ALL_YOUR_BASE_H)
+#define ALL_YOUR_BASE_H
+
+namespace all_your_base {
+
+}  // namespace all_your_base
+
+#endif // ALL_YOUR_BASE_H

--- a/exercises/allergies/allergies.cpp
+++ b/exercises/allergies/allergies.cpp
@@ -1,0 +1,5 @@
+#include "allergies.h"
+
+namespace allergies {
+
+}  // namespace allergies

--- a/exercises/allergies/allergies.h
+++ b/exercises/allergies/allergies.h
@@ -1,0 +1,8 @@
+#if !defined(ALLERGIES_H)
+#define ALLERGIES_H
+
+namespace allergies {
+
+}  // namespace allergies
+
+#endif // ALLERGIES_H

--- a/exercises/anagram/anagram.cpp
+++ b/exercises/anagram/anagram.cpp
@@ -1,0 +1,5 @@
+#include "anagram.h"
+
+namespace anagram {
+
+}  // namespace anagram

--- a/exercises/anagram/anagram.h
+++ b/exercises/anagram/anagram.h
@@ -1,0 +1,8 @@
+#if !defined(ANAGRAM_H)
+#define ANAGRAM_H
+
+namespace anagram {
+
+}  // namespace anagram
+
+#endif // ANAGRAM_H

--- a/exercises/armstrong-numbers/armstrong_numbers.cpp
+++ b/exercises/armstrong-numbers/armstrong_numbers.cpp
@@ -1,0 +1,5 @@
+#include "armstrong_numbers.h"
+
+namespace armstrong_numbers {
+
+}  // namespace armstrong_numbers

--- a/exercises/armstrong-numbers/armstrong_numbers.h
+++ b/exercises/armstrong-numbers/armstrong_numbers.h
@@ -1,0 +1,8 @@
+#if !defined(ARMSTRONG_NUMBERS_H)
+#define ARMSTRONG_NUMBERS_H
+
+namespace armstrong_numbers {
+
+}  // namespace armstrong_numbers
+
+#endif // ARMSTRONG_NUMBERS_H

--- a/exercises/atbash-cipher/atbash_cipher.cpp
+++ b/exercises/atbash-cipher/atbash_cipher.cpp
@@ -1,0 +1,5 @@
+#include "atbash_cipher.h"
+
+namespace atbash_cipher {
+
+}  // namespace atbash_cipher

--- a/exercises/atbash-cipher/atbash_cipher.h
+++ b/exercises/atbash-cipher/atbash_cipher.h
@@ -1,0 +1,8 @@
+#if !defined(ATBASH_CIPHER_H)
+#define ATBASH_CIPHER_H
+
+namespace atbash_cipher {
+
+}  // namespace atbash_cipher
+
+#endif // ATBASH_CIPHER_H

--- a/exercises/atbash-cipher/atbash_cipher_test.cpp
+++ b/exercises/atbash-cipher/atbash_cipher_test.cpp
@@ -3,65 +3,65 @@
 
 TEST_CASE("encode_yes")
 {
-    REQUIRE("bvh" == atbash::encode("yes"));
+    REQUIRE("bvh" == atbash_cipher::encode("yes"));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("encode_no")
 {
-    REQUIRE("ml" == atbash::encode("no"));
+    REQUIRE("ml" == atbash_cipher::encode("no"));
 }
 
 TEST_CASE("encode_OMG")
 {
-    REQUIRE("lnt" == atbash::encode("OMG"));
+    REQUIRE("lnt" == atbash_cipher::encode("OMG"));
 }
 
 TEST_CASE("encode_spaces")
 {
-    REQUIRE("lnt" == atbash::encode("O M G"));
+    REQUIRE("lnt" == atbash_cipher::encode("O M G"));
 }
 
 TEST_CASE("encode_mindblowingly")
 {
-    REQUIRE("nrmwy oldrm tob" == atbash::encode("mindblowingly"));
+    REQUIRE("nrmwy oldrm tob" == atbash_cipher::encode("mindblowingly"));
 }
 
 TEST_CASE("encode_numbers")
 {
-    REQUIRE("gvhgr mt123 gvhgr mt" == atbash::encode("Testing,1 2 3, testing."));
+    REQUIRE("gvhgr mt123 gvhgr mt" == atbash_cipher::encode("Testing,1 2 3, testing."));
 }
 
 TEST_CASE("encode_deep_thought")
 {
-    REQUIRE("gifgs rhurx grlm" == atbash::encode("Truth is fiction."));
+    REQUIRE("gifgs rhurx grlm" == atbash_cipher::encode("Truth is fiction."));
 }
 
 TEST_CASE("encode_all_the_letters")
 {
     REQUIRE("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt" ==
-                        atbash::encode("The quick brown fox jumps over the lazy dog."));
+                        atbash_cipher::encode("The quick brown fox jumps over the lazy dog."));
 }
 
 TEST_CASE("decode_exercism")
 {
-    REQUIRE("exercism" == atbash::decode("vcvix rhn"));
+    REQUIRE("exercism" == atbash_cipher::decode("vcvix rhn"));
 }
 
 TEST_CASE("decode_a_sentence")
 {
     REQUIRE("anobstacleisoftenasteppingstone" ==
-                        atbash::decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"));
+                        atbash_cipher::decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"));
 }
 
 TEST_CASE("decode_numbers")
 {
-    REQUIRE("testing123testing" == atbash::decode("gvhgr mt123 gvhgr mt"));
+    REQUIRE("testing123testing" == atbash_cipher::decode("gvhgr mt123 gvhgr mt"));
 }
 
 TEST_CASE("decode_all_the_letters")
 {
     REQUIRE("thequickbrownfoxjumpsoverthelazydog" ==
-                        atbash::decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"));
+                        atbash_cipher::decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"));
 }
 #endif

--- a/exercises/atbash-cipher/example.cpp
+++ b/exercises/atbash-cipher/example.cpp
@@ -3,7 +3,7 @@
 
 #include "atbash_cipher.h"
 
-namespace atbash {
+namespace atbash_cipher {
 
 const char ALPHA_START = 'a';
 const char ALPHA_END = 'z';

--- a/exercises/atbash-cipher/example.h
+++ b/exercises/atbash-cipher/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace atbash
+namespace atbash_cipher
 {
 
 std::string encode(std::string const& plaintext);

--- a/exercises/beer-song/beer_song.cpp
+++ b/exercises/beer-song/beer_song.cpp
@@ -1,0 +1,5 @@
+#include "beer_song.h"
+
+namespace beer_song {
+
+}  // namespace beer_song

--- a/exercises/beer-song/beer_song.h
+++ b/exercises/beer-song/beer_song.h
@@ -1,0 +1,8 @@
+#if !defined(BEER_SONG_H)
+#define BEER_SONG_H
+
+namespace beer_song {
+
+}  // namespace beer_song
+
+#endif // BEER_SONG_H

--- a/exercises/beer-song/beer_song_test.cpp
+++ b/exercises/beer-song/beer_song_test.cpp
@@ -8,7 +8,7 @@ TEST_CASE("prints_an_arbitrary_verse")
     string expected = "8 bottles of beer on the wall, 8 bottles of beer.\n"
         "Take one down and pass it around, 7 bottles of beer on the wall.\n";
 
-    REQUIRE(expected == beer::verse(8));
+    REQUIRE(expected == beer_song::verse(8));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -17,7 +17,7 @@ TEST_CASE("handles_1_bottle")
     string expected = "1 bottle of beer on the wall, 1 bottle of beer.\n"
         "Take it down and pass it around, no more bottles of beer on the wall.\n";
 
-    REQUIRE(expected == beer::verse(1));
+    REQUIRE(expected == beer_song::verse(1));
 }
 
 TEST_CASE("handles_0_bottles")
@@ -25,7 +25,7 @@ TEST_CASE("handles_0_bottles")
     string expected = "No more bottles of beer on the wall, no more bottles of beer.\n"
         "Go to the store and buy some more, 99 bottles of beer on the wall.\n";
 
-    REQUIRE(expected == beer::verse(0));
+    REQUIRE(expected == beer_song::verse(0));
 }
 
 TEST_CASE("sings_several_verses")
@@ -39,7 +39,7 @@ TEST_CASE("sings_several_verses")
         "6 bottles of beer on the wall, 6 bottles of beer.\n"
         "Take one down and pass it around, 5 bottles of beer on the wall.\n";
 
-    REQUIRE(expected == beer::sing(8, 6));
+    REQUIRE(expected == beer_song::sing(8, 6));
 }
 
 TEST_CASE("sings_the_rest_of_the_verses")
@@ -56,6 +56,6 @@ TEST_CASE("sings_the_rest_of_the_verses")
         "No more bottles of beer on the wall, no more bottles of beer.\n"
         "Go to the store and buy some more, 99 bottles of beer on the wall.\n";
 
-    REQUIRE(expected == beer::sing(3));
+    REQUIRE(expected == beer_song::sing(3));
 }
 #endif

--- a/exercises/beer-song/example.cpp
+++ b/exercises/beer-song/example.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-namespace beer
+namespace beer_song
 {
 
 namespace

--- a/exercises/beer-song/example.h
+++ b/exercises/beer-song/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace beer
+namespace beer_song
 {
 
 std::string verse(unsigned bottles);

--- a/exercises/binary-search-tree/binary_search_tree.cpp
+++ b/exercises/binary-search-tree/binary_search_tree.cpp
@@ -1,0 +1,5 @@
+#include "binary_search_tree.h"
+
+namespace binary_search_tree {
+
+}  // namespace binary_search_tree

--- a/exercises/binary-search-tree/binary_search_tree.h
+++ b/exercises/binary-search-tree/binary_search_tree.h
@@ -1,0 +1,8 @@
+#if !defined(BINARY_SEARCH_TREE_H)
+#define BINARY_SEARCH_TREE_H
+
+namespace binary_search_tree {
+
+}  // namespace binary_search_tree
+
+#endif // BINARY_SEARCH_TREE_H

--- a/exercises/binary-search-tree/binary_search_tree_test.cpp
+++ b/exercises/binary-search-tree/binary_search_tree_test.cpp
@@ -5,7 +5,7 @@
 // test data version: 1.0.0
 
 template<typename T>
-using tree_ptr = typename std::unique_ptr<binary_tree::binary_tree<T>>;
+using tree_ptr = typename std::unique_ptr<binary_search_tree::binary_tree<T>>;
 
 template<typename T>
 static void test_leaf(const tree_ptr<T> &tree, 
@@ -23,7 +23,7 @@ static tree_ptr<T> make_tree(const std::vector<T> &data)
         return tree_ptr<T>(nullptr);
     
     auto data_iter = data.begin();
-    auto tree = tree_ptr<T>(new binary_tree::binary_tree<T>(*data_iter));
+    auto tree = tree_ptr<T>(new binary_search_tree::binary_tree<T>(*data_iter));
     ++data_iter;
 
     for (; data_iter != data.end(); ++data_iter)

--- a/exercises/binary-search-tree/example.h
+++ b/exercises/binary-search-tree/example.h
@@ -55,8 +55,8 @@ namespace binary_search_tree
     public:
         class binary_tree_iter final
         {
-            friend binary_tree_iter binary_search_tree::begin() const;
-            friend binary_tree_iter binary_search_tree::end() const;
+            friend binary_tree_iter binary_tree::begin() const;
+            friend binary_tree_iter binary_tree::end() const;
         public:
             using binary_tree_iter_ptr = std::unique_ptr<binary_tree_iter>;
         private:

--- a/exercises/binary-search-tree/example.h
+++ b/exercises/binary-search-tree/example.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <utility>
 
-namespace binary_tree
+namespace binary_search_tree
 {
     template <bool B, class T = void>
     using enable_if_t = typename std::enable_if<B, T>::type;
@@ -55,8 +55,8 @@ namespace binary_tree
     public:
         class binary_tree_iter final
         {
-            friend binary_tree_iter binary_tree::begin() const;
-            friend binary_tree_iter binary_tree::end() const;
+            friend binary_tree_iter binary_search_tree::begin() const;
+            friend binary_tree_iter binary_search_tree::end() const;
         public:
             using binary_tree_iter_ptr = std::unique_ptr<binary_tree_iter>;
         private:

--- a/exercises/binary-search/binary_search.cpp
+++ b/exercises/binary-search/binary_search.cpp
@@ -1,0 +1,5 @@
+#include "binary_search.h"
+
+namespace binary_search {
+
+}  // namespace binary_search

--- a/exercises/binary-search/binary_search.h
+++ b/exercises/binary-search/binary_search.h
@@ -1,0 +1,8 @@
+#if !defined(BINARY_SEARCH_H)
+#define BINARY_SEARCH_H
+
+namespace binary_search {
+
+}  // namespace binary_search
+
+#endif // BINARY_SEARCH_H

--- a/exercises/binary/binary.cpp
+++ b/exercises/binary/binary.cpp
@@ -1,0 +1,5 @@
+#include "binary.h"
+
+namespace binary {
+
+}  // namespace binary

--- a/exercises/binary/binary.h
+++ b/exercises/binary/binary.h
@@ -1,0 +1,8 @@
+#if !defined(BINARY_H)
+#define BINARY_H
+
+namespace binary {
+
+}  // namespace binary
+
+#endif // BINARY_H

--- a/exercises/bob/bob.cpp
+++ b/exercises/bob/bob.cpp
@@ -1,0 +1,5 @@
+#include "bob.h"
+
+namespace bob {
+
+}  // namespace bob

--- a/exercises/bob/bob.h
+++ b/exercises/bob/bob.h
@@ -1,0 +1,8 @@
+#if !defined(BOB_H)
+#define BOB_H
+
+namespace bob {
+
+}  // namespace bob
+
+#endif // BOB_H

--- a/exercises/circular-buffer/circular_buffer.cpp
+++ b/exercises/circular-buffer/circular_buffer.cpp
@@ -1,0 +1,5 @@
+#include "circular_buffer.h"
+
+namespace circular_buffer {
+
+}  // namespace circular_buffer

--- a/exercises/circular-buffer/circular_buffer.h
+++ b/exercises/circular-buffer/circular_buffer.h
@@ -1,0 +1,8 @@
+#if !defined(CIRCULAR_BUFFER_H)
+#define CIRCULAR_BUFFER_H
+
+namespace circular_buffer {
+
+}  // namespace circular_buffer
+
+#endif // CIRCULAR_BUFFER_H

--- a/exercises/clock/clock.cpp
+++ b/exercises/clock/clock.cpp
@@ -1,5 +1,5 @@
 #include "clock.h"
 
-namespace clock {
+namespace date_independent {
 
-}  // namespace clock
+}  // namespace date_independent

--- a/exercises/clock/clock.cpp
+++ b/exercises/clock/clock.cpp
@@ -1,0 +1,5 @@
+#include "clock.h"
+
+namespace clock {
+
+}  // namespace clock

--- a/exercises/clock/clock.h
+++ b/exercises/clock/clock.h
@@ -1,8 +1,8 @@
 #if !defined(CLOCK_H)
 #define CLOCK_H
 
-namespace clock {
+namespace date_independent {
 
-}  // namespace clock
+}  // namespace date_independent
 
 #endif // CLOCK_H

--- a/exercises/clock/clock.h
+++ b/exercises/clock/clock.h
@@ -1,0 +1,8 @@
+#if !defined(CLOCK_H)
+#define CLOCK_H
+
+namespace clock {
+
+}  // namespace clock
+
+#endif // CLOCK_H

--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -176,7 +176,7 @@ string errorMsg(string expected, string actual, string test)
 TEST_CASE("time_tests")
 {
     for (timeTest t : timeCases) {
-        const auto actual = string(clock::clock::at(t.hour, t.minute));
+        const auto actual = string(date_independent::clock::at(t.hour, t.minute));
 
         INFO(errorMsg(t.expected, actual, t.msg));
         REQUIRE(t.expected == actual);
@@ -187,7 +187,7 @@ TEST_CASE("time_tests")
 TEST_CASE("add_tests")
 {
     for (addTest a : addCases) {
-        const auto actual = string(clock::clock::at(a.hour, a.minute).plus(a.add));
+        const auto actual = string(date_independent::clock::at(a.hour, a.minute).plus(a.add));
 
         INFO(errorMsg(a.expected, actual, a.msg));
         REQUIRE(a.expected == actual);
@@ -197,8 +197,8 @@ TEST_CASE("add_tests")
 TEST_CASE("equal_tests")
 {
     for (equalTest e : equalCases) {
-        const auto clock1 = clock::clock::at(e.c1.hour, e.c1.minute);
-        const auto clock2 = clock::clock::at(e.c2.hour, e.c2.minute);
+        const auto clock1 = date_independent::clock::at(e.c1.hour, e.c1.minute);
+        const auto clock2 = date_independent::clock::at(e.c2.hour, e.c2.minute);
 
         if (e.expected) {
             INFO(errorMsg(string(clock1), string(clock2), e.msg));

--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -176,7 +176,7 @@ string errorMsg(string expected, string actual, string test)
 TEST_CASE("time_tests")
 {
     for (timeTest t : timeCases) {
-        const auto actual = string(date_independent::clock::at(t.hour, t.minute));
+        const auto actual = string(clock::clock::at(t.hour, t.minute));
 
         INFO(errorMsg(t.expected, actual, t.msg));
         REQUIRE(t.expected == actual);
@@ -187,7 +187,7 @@ TEST_CASE("time_tests")
 TEST_CASE("add_tests")
 {
     for (addTest a : addCases) {
-        const auto actual = string(date_independent::clock::at(a.hour, a.minute).plus(a.add));
+        const auto actual = string(clock::clock::at(a.hour, a.minute).plus(a.add));
 
         INFO(errorMsg(a.expected, actual, a.msg));
         REQUIRE(a.expected == actual);
@@ -197,8 +197,8 @@ TEST_CASE("add_tests")
 TEST_CASE("equal_tests")
 {
     for (equalTest e : equalCases) {
-        const auto clock1 = date_independent::clock::at(e.c1.hour, e.c1.minute);
-        const auto clock2 = date_independent::clock::at(e.c2.hour, e.c2.minute);
+        const auto clock1 = clock::clock::at(e.c1.hour, e.c1.minute);
+        const auto clock2 = clock::clock::at(e.c2.hour, e.c2.minute);
 
         if (e.expected) {
             INFO(errorMsg(string(clock1), string(clock2), e.msg));

--- a/exercises/clock/example.cpp
+++ b/exercises/clock/example.cpp
@@ -12,7 +12,7 @@ const int hours_per_day = 24;
 
 }
 
-namespace clock
+namespace date_independent
 {
 
 clock& clock::plus(int minutes)

--- a/exercises/clock/example.cpp
+++ b/exercises/clock/example.cpp
@@ -12,7 +12,7 @@ const int hours_per_day = 24;
 
 }
 
-namespace date_independent
+namespace clock
 {
 
 clock& clock::plus(int minutes)

--- a/exercises/clock/example.h
+++ b/exercises/clock/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace clock
+namespace date_independent
 {
 
 class clock

--- a/exercises/clock/example.h
+++ b/exercises/clock/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace date_independent
+namespace clock
 {
 
 class clock

--- a/exercises/collatz-conjecture/collatz_conjecture.cpp
+++ b/exercises/collatz-conjecture/collatz_conjecture.cpp
@@ -1,0 +1,5 @@
+#include "collatz_conjecture.h"
+
+namespace collatz_conjecture {
+
+}  // namespace collatz_conjecture

--- a/exercises/collatz-conjecture/collatz_conjecture.h
+++ b/exercises/collatz-conjecture/collatz_conjecture.h
@@ -1,0 +1,8 @@
+#if !defined(COLLATZ_CONJECTURE_H)
+#define COLLATZ_CONJECTURE_H
+
+namespace collatz_conjecture {
+
+}  // namespace collatz_conjecture
+
+#endif // COLLATZ_CONJECTURE_H

--- a/exercises/crypto-square/crypto_square.cpp
+++ b/exercises/crypto-square/crypto_square.cpp
@@ -1,0 +1,5 @@
+#include "crypto_square.h"
+
+namespace crypto_square {
+
+}  // namespace crypto_square

--- a/exercises/crypto-square/crypto_square.h
+++ b/exercises/crypto-square/crypto_square.h
@@ -1,0 +1,8 @@
+#if !defined(CRYPTO_SQUARE_H)
+#define CRYPTO_SQUARE_H
+
+namespace crypto_square {
+
+}  // namespace crypto_square
+
+#endif // CRYPTO_SQUARE_H

--- a/exercises/difference-of-squares/difference_of_squares.cpp
+++ b/exercises/difference-of-squares/difference_of_squares.cpp
@@ -1,0 +1,5 @@
+#include "difference_of_squares.h"
+
+namespace difference_of_squares {
+
+}  // namespace difference_of_squares

--- a/exercises/difference-of-squares/difference_of_squares.h
+++ b/exercises/difference-of-squares/difference_of_squares.h
@@ -1,0 +1,8 @@
+#if !defined(DIFFERENCE_OF_SQUARES_H)
+#define DIFFERENCE_OF_SQUARES_H
+
+namespace difference_of_squares {
+
+}  // namespace difference_of_squares
+
+#endif // DIFFERENCE_OF_SQUARES_H

--- a/exercises/difference-of-squares/difference_of_squares_test.cpp
+++ b/exercises/difference-of-squares/difference_of_squares_test.cpp
@@ -3,23 +3,23 @@
 
 TEST_CASE("up_to_5")
 {
-    REQUIRE(225 == squares::square_of_sum(5));
-    REQUIRE(55 == squares::sum_of_squares(5));
-    REQUIRE(170 == squares::difference(5));
+    REQUIRE(225 == difference_of_squares::square_of_sum(5));
+    REQUIRE(55 == difference_of_squares::sum_of_squares(5));
+    REQUIRE(170 == difference_of_squares::difference(5));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("up_to_10")
 {
-    REQUIRE(3025 == squares::square_of_sum(10));
-    REQUIRE(385 == squares::sum_of_squares(10));
-    REQUIRE(2640 == squares::difference(10));
+    REQUIRE(3025 == difference_of_squares::square_of_sum(10));
+    REQUIRE(385 == difference_of_squares::sum_of_squares(10));
+    REQUIRE(2640 == difference_of_squares::difference(10));
 }
 
 TEST_CASE("up_to_100")
 {
-    REQUIRE(25502500 == squares::square_of_sum(100));
-    REQUIRE(338350 == squares::sum_of_squares(100));
-    REQUIRE(25164150 == squares::difference(100));
+    REQUIRE(25502500 == difference_of_squares::square_of_sum(100));
+    REQUIRE(338350 == difference_of_squares::sum_of_squares(100));
+    REQUIRE(25164150 == difference_of_squares::difference(100));
 }
 #endif

--- a/exercises/difference-of-squares/example.cpp
+++ b/exercises/difference-of-squares/example.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-namespace squares
+namespace difference_of_squares
 {
 
 int square_of_sum(int n)

--- a/exercises/difference-of-squares/example.h
+++ b/exercises/difference-of-squares/example.h
@@ -1,7 +1,7 @@
 #if !defined(DIFFERENCE_OF_SQUARES_H)
 #define DIFFERENCE_OF_SQUARES_H
 
-namespace squares
+namespace difference_of_squares
 {
 
 int square_of_sum(int n);

--- a/exercises/etl/etl.cpp
+++ b/exercises/etl/etl.cpp
@@ -1,0 +1,5 @@
+#include "etl.h"
+
+namespace etl {
+
+}  // namespace etl

--- a/exercises/etl/etl.h
+++ b/exercises/etl/etl.h
@@ -1,0 +1,8 @@
+#if !defined(ETL_H)
+#define ETL_H
+
+namespace etl {
+
+}  // namespace etl
+
+#endif // ETL_H

--- a/exercises/food-chain/food_chain.cpp
+++ b/exercises/food-chain/food_chain.cpp
@@ -1,0 +1,5 @@
+#include "food_chain.h"
+
+namespace food_chain {
+
+}  // namespace food_chain

--- a/exercises/food-chain/food_chain.h
+++ b/exercises/food-chain/food_chain.h
@@ -1,0 +1,8 @@
+#if !defined(FOOD_CHAIN_H)
+#define FOOD_CHAIN_H
+
+namespace food_chain {
+
+}  // namespace food_chain
+
+#endif // FOOD_CHAIN_H

--- a/exercises/gigasecond/gigasecond.cpp
+++ b/exercises/gigasecond/gigasecond.cpp
@@ -1,0 +1,5 @@
+#include "gigasecond.h"
+
+namespace gigasecond {
+
+}  // namespace gigasecond

--- a/exercises/gigasecond/gigasecond.h
+++ b/exercises/gigasecond/gigasecond.h
@@ -1,0 +1,8 @@
+#if !defined(GIGASECOND_H)
+#define GIGASECOND_H
+
+namespace gigasecond {
+
+}  // namespace gigasecond
+
+#endif // GIGASECOND_H

--- a/exercises/grade-school/grade_school.cpp
+++ b/exercises/grade-school/grade_school.cpp
@@ -1,0 +1,5 @@
+#include "grade_school.h"
+
+namespace grade_school {
+
+}  // namespace grade_school

--- a/exercises/grade-school/grade_school.h
+++ b/exercises/grade-school/grade_school.h
@@ -1,0 +1,8 @@
+#if !defined(GRADE_SCHOOL_H)
+#define GRADE_SCHOOL_H
+
+namespace grade_school {
+
+}  // namespace grade_school
+
+#endif // GRADE_SCHOOL_H

--- a/exercises/grains/grains.cpp
+++ b/exercises/grains/grains.cpp
@@ -1,0 +1,5 @@
+#include "grains.h"
+
+namespace grains {
+
+}  // namespace grains

--- a/exercises/grains/grains.h
+++ b/exercises/grains/grains.h
@@ -1,0 +1,8 @@
+#if !defined(GRAINS_H)
+#define GRAINS_H
+
+namespace grains {
+
+}  // namespace grains
+
+#endif // GRAINS_H

--- a/exercises/hamming/hamming.cpp
+++ b/exercises/hamming/hamming.cpp
@@ -1,0 +1,5 @@
+#include "hamming.h"
+
+namespace hamming {
+
+}  // namespace hamming

--- a/exercises/hamming/hamming.h
+++ b/exercises/hamming/hamming.h
@@ -1,0 +1,8 @@
+#if !defined(HAMMING_H)
+#define HAMMING_H
+
+namespace hamming {
+
+}  // namespace hamming
+
+#endif // HAMMING_H

--- a/exercises/hexadecimal/hexadecimal.cpp
+++ b/exercises/hexadecimal/hexadecimal.cpp
@@ -1,0 +1,5 @@
+#include "hexadecimal.h"
+
+namespace hexadecimal {
+
+}  // namespace hexadecimal

--- a/exercises/hexadecimal/hexadecimal.h
+++ b/exercises/hexadecimal/hexadecimal.h
@@ -1,0 +1,8 @@
+#if !defined(HEXADECIMAL_H)
+#define HEXADECIMAL_H
+
+namespace hexadecimal {
+
+}  // namespace hexadecimal
+
+#endif // HEXADECIMAL_H

--- a/exercises/isogram/isogram.cpp
+++ b/exercises/isogram/isogram.cpp
@@ -1,0 +1,5 @@
+#include "isogram.h"
+
+namespace isogram {
+
+}  // namespace isogram

--- a/exercises/isogram/isogram.h
+++ b/exercises/isogram/isogram.h
@@ -1,0 +1,8 @@
+#if !defined(ISOGRAM_H)
+#define ISOGRAM_H
+
+namespace isogram {
+
+}  // namespace isogram
+
+#endif // ISOGRAM_H

--- a/exercises/leap/leap.cpp
+++ b/exercises/leap/leap.cpp
@@ -1,0 +1,5 @@
+#include "leap.h"
+
+namespace leap {
+
+}  // namespace leap

--- a/exercises/leap/leap.h
+++ b/exercises/leap/leap.h
@@ -1,0 +1,8 @@
+#if !defined(LEAP_H)
+#define LEAP_H
+
+namespace leap {
+
+}  // namespace leap
+
+#endif // LEAP_H

--- a/exercises/luhn/luhn.cpp
+++ b/exercises/luhn/luhn.cpp
@@ -1,0 +1,5 @@
+#include "luhn.h"
+
+namespace luhn {
+
+}  // namespace luhn

--- a/exercises/luhn/luhn.h
+++ b/exercises/luhn/luhn.h
@@ -1,0 +1,8 @@
+#if !defined(LUHN_H)
+#define LUHN_H
+
+namespace luhn {
+
+}  // namespace luhn
+
+#endif // LUHN_H

--- a/exercises/matching-brackets/matching_brackets.cpp
+++ b/exercises/matching-brackets/matching_brackets.cpp
@@ -1,0 +1,5 @@
+#include "matching_brackets.h"
+
+namespace matching_brackets {
+
+}  // namespace matching_brackets

--- a/exercises/matching-brackets/matching_brackets.h
+++ b/exercises/matching-brackets/matching_brackets.h
@@ -1,0 +1,8 @@
+#if !defined(MATCHING_BRACKETS_H)
+#define MATCHING_BRACKETS_H
+
+namespace matching_brackets {
+
+}  // namespace matching_brackets
+
+#endif // MATCHING_BRACKETS_H

--- a/exercises/meetup/meetup.cpp
+++ b/exercises/meetup/meetup.cpp
@@ -1,0 +1,5 @@
+#include "meetup.h"
+
+namespace meetup {
+
+}  // namespace meetup

--- a/exercises/meetup/meetup.h
+++ b/exercises/meetup/meetup.h
@@ -1,0 +1,8 @@
+#if !defined(MEETUP_H)
+#define MEETUP_H
+
+namespace meetup {
+
+}  // namespace meetup
+
+#endif // MEETUP_H

--- a/exercises/nth-prime/example.cpp
+++ b/exercises/nth-prime/example.cpp
@@ -15,7 +15,7 @@ bool is_prime(int n)
 }
 }
 
-int prime::nth(int n)
+int nth_prime::nth(int n)
 {
     if (n < 1) {
         throw std::domain_error("Out of range");

--- a/exercises/nth-prime/example.h
+++ b/exercises/nth-prime/example.h
@@ -1,7 +1,7 @@
 #if !defined(NTH_PRIME_H)
 #define NTH_PRIME_H
 
-namespace prime
+namespace nth_prime
 {
 int nth(int n);
 }

--- a/exercises/nth-prime/nth_prime.cpp
+++ b/exercises/nth-prime/nth_prime.cpp
@@ -1,0 +1,5 @@
+#include "nth_prime.h"
+
+namespace nth_prime {
+
+}  // namespace nth_prime

--- a/exercises/nth-prime/nth_prime.h
+++ b/exercises/nth-prime/nth_prime.h
@@ -1,0 +1,8 @@
+#if !defined(NTH_PRIME_H)
+#define NTH_PRIME_H
+
+namespace nth_prime {
+
+}  // namespace nth_prime
+
+#endif // NTH_PRIME_H

--- a/exercises/nth-prime/nth_prime_test.cpp
+++ b/exercises/nth-prime/nth_prime_test.cpp
@@ -4,27 +4,27 @@
 
 TEST_CASE("first")
 {
-    REQUIRE(2 == prime::nth(1));
+    REQUIRE(2 == nth_prime::nth(1));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("second")
 {
-    REQUIRE(3 == prime::nth(2));
+    REQUIRE(3 == nth_prime::nth(2));
 }
 
 TEST_CASE("sixth")
 {
-    REQUIRE(13 == prime::nth(6));
+    REQUIRE(13 == nth_prime::nth(6));
 }
 
 TEST_CASE("big_prime")
 {
-    REQUIRE(104743 == prime::nth(10001));
+    REQUIRE(104743 == nth_prime::nth(10001));
 }
 
 TEST_CASE("weird_case")
 {
-    REQUIRE_THROWS_AS(prime::nth(0), std::domain_error);
+    REQUIRE_THROWS_AS(nth_prime::nth(0), std::domain_error);
 }
 #endif

--- a/exercises/nucleotide-count/example.cpp
+++ b/exercises/nucleotide-count/example.cpp
@@ -1,7 +1,7 @@
 #include "nucleotide_count.h"
 #include <stdexcept>
 
-namespace dna
+namespace nucleotide_count
 {
 
 counter::counter(std::string const& sequence)

--- a/exercises/nucleotide-count/example.h
+++ b/exercises/nucleotide-count/example.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <string>
 
-namespace dna
+namespace nucleotide_count
 {
 
 class counter

--- a/exercises/nucleotide-count/nucleotide_count.cpp
+++ b/exercises/nucleotide-count/nucleotide_count.cpp
@@ -1,0 +1,5 @@
+#include "nucleotide_count.h"
+
+namespace nucleotide_count {
+
+}  // namespace nucleotide_count

--- a/exercises/nucleotide-count/nucleotide_count.h
+++ b/exercises/nucleotide-count/nucleotide_count.h
@@ -1,0 +1,8 @@
+#if !defined(NUCLEOTIDE_COUNT_H)
+#define NUCLEOTIDE_COUNT_H
+
+namespace nucleotide_count {
+
+}  // namespace nucleotide_count
+
+#endif // NUCLEOTIDE_COUNT_H

--- a/exercises/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/nucleotide-count/nucleotide_count_test.cpp
@@ -5,7 +5,7 @@
 
 TEST_CASE("has_no_nucleotides")
 {
-    const dna::counter dna("");
+    const nucleotide_count::counter dna("");
     const std::map<char, int> expected{ {'A', 0}, {'T', 0}, {'C', 0}, {'G', 0} };
 
     const auto actual = dna.nucleotide_counts();
@@ -16,21 +16,21 @@ TEST_CASE("has_no_nucleotides")
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("has_no_adenosine")
 {
-    const dna::counter dna("");
+    const nucleotide_count::counter dna("");
 
     REQUIRE(0 == dna.count('A'));
 }
 
 TEST_CASE("repetitive_cytidine_gets_counts")
 {
-    const dna::counter dna("CCCCC");
+    const nucleotide_count::counter dna("CCCCC");
 
     REQUIRE(5 == dna.count('C'));
 }
 
 TEST_CASE("repetitive_sequence_has_only_guanosine")
 {
-    const dna::counter dna("GGGGGGGG");
+    const nucleotide_count::counter dna("GGGGGGGG");
     const std::map<char, int> expected{ {'A', 0}, {'T', 0}, {'C', 0}, {'G', 8} };
 
     const auto actual = dna.nucleotide_counts();
@@ -40,14 +40,14 @@ TEST_CASE("repetitive_sequence_has_only_guanosine")
 
 TEST_CASE("counts_only_thymidine")
 {
-    const dna::counter dna("GGGGTAACCCGG");
+    const nucleotide_count::counter dna("GGGGTAACCCGG");
 
     REQUIRE(1 == dna.count('T'));
 }
 
 TEST_CASE("counts_a_nucleotide_only_once")
 {
-    const dna::counter dna("GGTTGG");
+    const nucleotide_count::counter dna("GGTTGG");
 
     dna.count('T');
 
@@ -56,19 +56,19 @@ TEST_CASE("counts_a_nucleotide_only_once")
 
 TEST_CASE("validates_nucleotides")
 {
-    const dna::counter dna("GGTTGG");
+    const nucleotide_count::counter dna("GGTTGG");
 
     REQUIRE_THROWS_AS(dna.count('X'), std::invalid_argument);
 }
 
 TEST_CASE("validates_nucleotides_on_construction")
 {
-    REQUIRE_THROWS_AS(dna::counter("GGTTGGX"), std::invalid_argument);
+    REQUIRE_THROWS_AS(nucleotide_count::counter("GGTTGGX"), std::invalid_argument);
 }
 
 TEST_CASE("counts_all_nucleotides")
 {
-    const dna::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
+    const nucleotide_count::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
     std::map<char, int> expected{ {'A', 20}, {'T', 21}, {'G', 17}, {'C', 12} };
 
     auto actual = dna.nucleotide_counts();

--- a/exercises/pangram/pangram.cpp
+++ b/exercises/pangram/pangram.cpp
@@ -1,0 +1,5 @@
+#include "pangram.h"
+
+namespace pangram {
+
+}  // namespace pangram

--- a/exercises/pangram/pangram.h
+++ b/exercises/pangram/pangram.h
@@ -1,0 +1,8 @@
+#if !defined(PANGRAM_H)
+#define PANGRAM_H
+
+namespace pangram {
+
+}  // namespace pangram
+
+#endif // PANGRAM_H

--- a/exercises/pascals-triangle/pascals_triangle.cpp
+++ b/exercises/pascals-triangle/pascals_triangle.cpp
@@ -1,0 +1,5 @@
+#include "pascals_triangle.h"
+
+namespace pascals_triangle {
+
+}  // namespace pascals_triangle

--- a/exercises/pascals-triangle/pascals_triangle.h
+++ b/exercises/pascals-triangle/pascals_triangle.h
@@ -1,0 +1,8 @@
+#if !defined(PASCALS_TRIANGLE_H)
+#define PASCALS_TRIANGLE_H
+
+namespace pascals_triangle {
+
+}  // namespace pascals_triangle
+
+#endif // PASCALS_TRIANGLE_H

--- a/exercises/phone-number/example.cpp
+++ b/exercises/phone-number/example.cpp
@@ -1,25 +1,27 @@
-#include "phone_number.h"
 #include <algorithm>
 #include <cctype>
-#include <stdexcept>
 #include <iterator>
 #include <sstream>
+#include <stdexcept>
+
+#include "phone_number.h"
+
+namespace phone_number {
 
 using namespace std;
 
-namespace
-{
+namespace {
 
 const int area_code_length = 3;
 const int exchange_length = 3;
 const int extension_length = 4;
-const int valid_number_length = area_code_length + exchange_length + extension_length;
+const int valid_number_length =
+    area_code_length + exchange_length + extension_length;
 
-string clean_number(const string& text)
-{
+string clean_number(const string& text) {
     string result;
     copy_if(text.begin(), text.end(), back_inserter(result),
-        [](char c) { return isdigit(c) != 0; });
+            [](char c) { return isdigit(c) != 0; });
     if (result.length() == valid_number_length + 1) {
         if (result[0] == '1') {
             result.erase(result.begin());
@@ -30,42 +32,33 @@ string clean_number(const string& text)
         throw std::domain_error("Invalid number");
     }
     if (result[0] < '2' || result[3] < '2') {
-      throw std::domain_error("Invalid number");
+        throw std::domain_error("Invalid number");
     }
     return result;
 }
 
-}
+}  // namespace
 
-phone_number::phone_number(const string& text)
-    : digits_(clean_number(text))
-{
-}
+phone_number::phone_number(const string& text) : digits_(clean_number(text)) {}
 
-string phone_number::area_code() const
-{
+string phone_number::area_code() const {
     return digits_.substr(0, area_code_length);
 }
 
-string phone_number::exchange() const
-{
+string phone_number::exchange() const {
     return digits_.substr(area_code_length, exchange_length);
 }
 
-string phone_number::extension() const
-{
+string phone_number::extension() const {
     return digits_.substr(area_code_length + exchange_length);
 }
 
-string phone_number::number() const
-{
-    return digits_;
-}
+string phone_number::number() const { return digits_; }
 
-phone_number::operator std::string() const
-{
+phone_number::operator std::string() const {
     ostringstream buff;
     buff << '(' << area_code() << ") " << exchange() << '-' << extension();
     return buff.str();
 }
 
+}  // namespace phone_number

--- a/exercises/phone-number/example.h
+++ b/exercises/phone-number/example.h
@@ -3,9 +3,10 @@
 
 #include <string>
 
-class phone_number
-{
-public:
+namespace phone_number {
+
+class phone_number {
+   public:
     phone_number(const std::string& text);
 
     std::string area_code() const;
@@ -13,12 +14,14 @@ public:
 
     explicit operator std::string() const;
 
-private:
+   private:
     std::string extension() const;
 
     std::string exchange() const;
 
     const std::string digits_;
 };
+
+}  // namespace phone_number
 
 #endif

--- a/exercises/phone-number/phone_number.cpp
+++ b/exercises/phone-number/phone_number.cpp
@@ -1,0 +1,5 @@
+#include "phone_number.h"
+
+namespace phone_number {
+
+}  // namespace phone_number

--- a/exercises/phone-number/phone_number.h
+++ b/exercises/phone-number/phone_number.h
@@ -1,0 +1,8 @@
+#if !defined(PHONE_NUMBER_H)
+#define PHONE_NUMBER_H
+
+namespace phone_number {
+
+}  // namespace phone_number
+
+#endif // PHONE_NUMBER_H

--- a/exercises/phone-number/phone_number_test.cpp
+++ b/exercises/phone-number/phone_number_test.cpp
@@ -4,91 +4,91 @@
 #include <exception>
 
 TEST_CASE("cleans_the_number") {
-  REQUIRE("2234567890" == phone_number("(223) 456-7890").number());
+  REQUIRE("2234567890" == phone_number::phone_number("(223) 456-7890").number());
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
 TEST_CASE("cleans_numbers_with_dots") {
-  REQUIRE("2234567890" == phone_number("223.456.7890").number());
+  REQUIRE("2234567890" == phone_number::phone_number("223.456.7890").number());
 }
 
 TEST_CASE("cleans_numbers_with_spaces") {
-  REQUIRE("2234567890" == phone_number("223 456   7890   ").number());
+  REQUIRE("2234567890" == phone_number::phone_number("223 456   7890   ").number());
 }
 
 TEST_CASE("has_an_area_code") {
-  REQUIRE("223" == phone_number("+1 (223) 456-7890").area_code());
+  REQUIRE("223" == phone_number::phone_number("+1 (223) 456-7890").area_code());
 }
 
 TEST_CASE("formats_a_number") {
-  const phone_number phone("+1 (223) 456-7890");
+  const phone_number::phone_number phone("+1 (223) 456-7890");
   REQUIRE("(223) 456-7890" == std::string(phone));
 }
 
 TEST_CASE("invalid_when_9_digits") {
-  REQUIRE_THROWS_AS(phone_number("123456789"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("123456789"), std::domain_error);
 }
 
 TEST_CASE("invalid_when_11_digits_does_not_start_with_a_1") {
-  REQUIRE_THROWS_AS(phone_number("22234567890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("22234567890"), std::domain_error);
 }
 
 TEST_CASE("valid_when_11_digits_and_starting_with_1") {
-  REQUIRE("2234567890" == phone_number("12234567890").number());
+  REQUIRE("2234567890" == phone_number::phone_number("12234567890").number());
 }
 
 TEST_CASE(
     "valid_when_11_digits_and_starting_with_1_even_with_punctuation") {
-  REQUIRE("2234567890" == phone_number("+1 (223) 456-7890").number());
+  REQUIRE("2234567890" == phone_number::phone_number("+1 (223) 456-7890").number());
 }
 
 TEST_CASE("invalid_when_more_than_11_digits") {
-  REQUIRE_THROWS_AS(phone_number("321234567890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("321234567890"), std::domain_error);
 }
 
 TEST_CASE("invalid_with_letters") {
-  REQUIRE_THROWS_AS(phone_number("123-abc-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("123-abc-7890"), std::domain_error);
 }
 
 TEST_CASE("invalid_with_punctuation") {
-  REQUIRE_THROWS_AS(phone_number("123-@:!-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("123-@:!-7890"), std::domain_error);
 }
 
 TEST_CASE("invalid_if_area_code_starts_with_0") {
-  REQUIRE_THROWS_AS(phone_number("(023) 456-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("(023) 456-7890"), std::domain_error);
 }
 
 TEST_CASE("invalid_if_area_code_starts_with_1") {
-  REQUIRE_THROWS_AS(phone_number("(123) 456-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("(123) 456-7890"), std::domain_error);
 }
 
 TEST_CASE("invalid_if_exchange_code_starts_with_0") {
-  REQUIRE_THROWS_AS(phone_number("(223) 056-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("(223) 056-7890"), std::domain_error);
 }
 
 TEST_CASE("invalid_if_exchange_code_starts_with_1") {
-  REQUIRE_THROWS_AS(phone_number("(223) 156-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("(223) 156-7890"), std::domain_error);
 }
 
 TEST_CASE(
     "invalid_if_area_code_starts_with_0_on_valid_11_digit_number") {
-  REQUIRE_THROWS_AS(phone_number("1 (023) 456-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("1 (023) 456-7890"), std::domain_error);
 }
 
 TEST_CASE(
     "invalid_if_area_code_starts_with_1_on_valid_11_digit_number") {
-  REQUIRE_THROWS_AS(phone_number("1 (123) 456-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("1 (123) 456-7890"), std::domain_error);
 }
 
 TEST_CASE(
     "invalid_if_exchange_code_starts_with_0_on_valid_11_digit_number") {
-  REQUIRE_THROWS_AS(phone_number("1 (223) 056-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("1 (223) 056-7890"), std::domain_error);
 }
 
 TEST_CASE(
     "invalid_if_exchange_code_starts_with_1_on_valid_11_digit_number") {
-  REQUIRE_THROWS_AS(phone_number("1 (223) 156-7890"), std::domain_error);
+  REQUIRE_THROWS_AS(phone_number::phone_number("1 (223) 156-7890"), std::domain_error);
 }
 
 #endif

--- a/exercises/prime-factors/prime_factors.cpp
+++ b/exercises/prime-factors/prime_factors.cpp
@@ -1,0 +1,5 @@
+#include "prime_factors.h"
+
+namespace prime_factors {
+
+}  // namespace prime_factors

--- a/exercises/prime-factors/prime_factors.h
+++ b/exercises/prime-factors/prime_factors.h
@@ -1,0 +1,8 @@
+#if !defined(PRIME_FACTORS_H)
+#define PRIME_FACTORS_H
+
+namespace prime_factors {
+
+}  // namespace prime_factors
+
+#endif // PRIME_FACTORS_H

--- a/exercises/queen-attack/queen_attack.cpp
+++ b/exercises/queen-attack/queen_attack.cpp
@@ -1,0 +1,5 @@
+#include "queen_attack.h"
+
+namespace queen_attack {
+
+}  // namespace queen_attack

--- a/exercises/queen-attack/queen_attack.h
+++ b/exercises/queen-attack/queen_attack.h
@@ -1,0 +1,8 @@
+#if !defined(QUEEN_ATTACK_H)
+#define QUEEN_ATTACK_H
+
+namespace queen_attack {
+
+}  // namespace queen_attack
+
+#endif // QUEEN_ATTACK_H

--- a/exercises/raindrops/raindrops.cpp
+++ b/exercises/raindrops/raindrops.cpp
@@ -1,0 +1,5 @@
+#include "raindrops.h"
+
+namespace raindrops {
+
+}  // namespace raindrops

--- a/exercises/raindrops/raindrops.h
+++ b/exercises/raindrops/raindrops.h
@@ -1,0 +1,8 @@
+#if !defined(RAINDROPS_H)
+#define RAINDROPS_H
+
+namespace raindrops {
+
+}  // namespace raindrops
+
+#endif // RAINDROPS_H

--- a/exercises/reverse-string/reverse_string.cpp
+++ b/exercises/reverse-string/reverse_string.cpp
@@ -1,0 +1,5 @@
+#include "reverse_string.h"
+
+namespace reverse_string {
+
+}  // namespace reverse_string

--- a/exercises/reverse-string/reverse_string.h
+++ b/exercises/reverse-string/reverse_string.h
@@ -1,0 +1,8 @@
+#if !defined(REVERSE_STRING_H)
+#define REVERSE_STRING_H
+
+namespace reverse_string {
+
+}  // namespace reverse_string
+
+#endif // REVERSE_STRING_H

--- a/exercises/rna-transcription/example.cpp
+++ b/exercises/rna-transcription/example.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-namespace transcription
+namespace rna_transcription
 {
 
 char to_rna(const char nucleotide)

--- a/exercises/rna-transcription/example.h
+++ b/exercises/rna-transcription/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace transcription
+namespace rna_transcription
 {
 
 char to_rna(char nucleotide);

--- a/exercises/rna-transcription/rna_transcription.cpp
+++ b/exercises/rna-transcription/rna_transcription.cpp
@@ -1,0 +1,5 @@
+#include "rna_transcription.h"
+
+namespace rna_transcription {
+
+}  // namespace rna_transcription

--- a/exercises/rna-transcription/rna_transcription.h
+++ b/exercises/rna-transcription/rna_transcription.h
@@ -1,0 +1,8 @@
+#if !defined(RNA_TRANSCRIPTION_H)
+#define RNA_TRANSCRIPTION_H
+
+namespace rna_transcription {
+
+}  // namespace rna_transcription
+
+#endif // RNA_TRANSCRIPTION_H

--- a/exercises/rna-transcription/rna_transcription_test.cpp
+++ b/exercises/rna-transcription/rna_transcription_test.cpp
@@ -3,27 +3,27 @@
 
 TEST_CASE("transcribes_cytidine_to_guanosine")
 {
-    REQUIRE('G' == transcription::to_rna('C'));
+    REQUIRE('G' == rna_transcription::to_rna('C'));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("transcribes_guanosine_to_cytidine")
 {
-    REQUIRE('C' == transcription::to_rna('G'));
+    REQUIRE('C' == rna_transcription::to_rna('G'));
 }
 
 TEST_CASE("transcribes_adenosine_to_uracil")
 {
-    REQUIRE('U' == transcription::to_rna('A'));
+    REQUIRE('U' == rna_transcription::to_rna('A'));
 }
 
 TEST_CASE("transcribes_thymidine_to_adenosine")
 {
-    REQUIRE('A' == transcription::to_rna('T'));
+    REQUIRE('A' == rna_transcription::to_rna('T'));
 }
 
 TEST_CASE("transcribes_all_dna_nucleotides_to_their_rna_complements")
 {
-    REQUIRE("UGCACCAGAAUU" == transcription::to_rna("ACGTGGTCTTAA"));
+    REQUIRE("UGCACCAGAAUU" == rna_transcription::to_rna("ACGTGGTCTTAA"));
 }
 #endif

--- a/exercises/robot-name/robot_name.cpp
+++ b/exercises/robot-name/robot_name.cpp
@@ -1,0 +1,5 @@
+#include "robot_name.h"
+
+namespace robot_name {
+
+}  // namespace robot_name

--- a/exercises/robot-name/robot_name.h
+++ b/exercises/robot-name/robot_name.h
@@ -1,0 +1,8 @@
+#if !defined(ROBOT_NAME_H)
+#define ROBOT_NAME_H
+
+namespace robot_name {
+
+}  // namespace robot_name
+
+#endif // ROBOT_NAME_H

--- a/exercises/robot-simulator/robot_simulator.cpp
+++ b/exercises/robot-simulator/robot_simulator.cpp
@@ -1,0 +1,5 @@
+#include "robot_simulator.h"
+
+namespace robot_simulator {
+
+}  // namespace robot_simulator

--- a/exercises/robot-simulator/robot_simulator.h
+++ b/exercises/robot-simulator/robot_simulator.h
@@ -1,0 +1,8 @@
+#if !defined(ROBOT_SIMULATOR_H)
+#define ROBOT_SIMULATOR_H
+
+namespace robot_simulator {
+
+}  // namespace robot_simulator
+
+#endif // ROBOT_SIMULATOR_H

--- a/exercises/roman-numerals/example.cpp
+++ b/exercises/roman-numerals/example.cpp
@@ -101,7 +101,7 @@ void converter::place_numeral_penultimate(int place, int penultimate_place)
 
 }
 
-std::string roman::convert(int n)
+std::string roman_numerals::convert(int n)
 {
     return converter(n).convert();
 }

--- a/exercises/roman-numerals/example.h
+++ b/exercises/roman-numerals/example.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-namespace roman
+namespace roman_numerals
 {
 
 std::string convert(int n);

--- a/exercises/roman-numerals/roman_numerals.cpp
+++ b/exercises/roman-numerals/roman_numerals.cpp
@@ -1,0 +1,5 @@
+#include "roman_numerals.h"
+
+namespace roman_numerals {
+
+}  // namespace roman_numerals

--- a/exercises/roman-numerals/roman_numerals.h
+++ b/exercises/roman-numerals/roman_numerals.h
@@ -1,0 +1,8 @@
+#if !defined(ROMAN_NUMERALS_H)
+#define ROMAN_NUMERALS_H
+
+namespace roman_numerals {
+
+}  // namespace roman_numerals
+
+#endif // ROMAN_NUMERALS_H

--- a/exercises/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/roman-numerals/roman_numerals_test.cpp
@@ -3,92 +3,92 @@
 
 TEST_CASE("one_yields_I")
 {
-    REQUIRE("I" == roman::convert(1));
+    REQUIRE("I" == roman_numerals::convert(1));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("two_yields_II")
 {
-    REQUIRE("II" == roman::convert(2));
+    REQUIRE("II" == roman_numerals::convert(2));
 }
 
 TEST_CASE("three_yields_III")
 {
-    REQUIRE("III" == roman::convert(3));
+    REQUIRE("III" == roman_numerals::convert(3));
 }
 
 TEST_CASE("four_yields_IV")
 {
-    REQUIRE("IV" == roman::convert(4));
+    REQUIRE("IV" == roman_numerals::convert(4));
 }
 
 TEST_CASE("five_yields_V")
 {
-    REQUIRE("V" == roman::convert(5));
+    REQUIRE("V" == roman_numerals::convert(5));
 }
 
 TEST_CASE("six_yields_VI")
 {
-    REQUIRE("VI" == roman::convert(6));
+    REQUIRE("VI" == roman_numerals::convert(6));
 }
 
 TEST_CASE("nine_yields_IX")
 {
-    REQUIRE("IX" == roman::convert(9));
+    REQUIRE("IX" == roman_numerals::convert(9));
 }
 
 TEST_CASE("twenty_seven_yields_XXVII")
 {
-    REQUIRE("XXVII" == roman::convert(27));
+    REQUIRE("XXVII" == roman_numerals::convert(27));
 }
 
 TEST_CASE("forty_eight_yields_XLVIII")
 {
-    REQUIRE("XLVIII" == roman::convert(48));
+    REQUIRE("XLVIII" == roman_numerals::convert(48));
 }
 
 TEST_CASE("fifty_nine_yields_LIX")
 {
-    REQUIRE("LIX" == roman::convert(59));
+    REQUIRE("LIX" == roman_numerals::convert(59));
 }
 
 TEST_CASE("ninety_three_yields_XCIII")
 {
-    REQUIRE("XCIII" == roman::convert(93));
+    REQUIRE("XCIII" == roman_numerals::convert(93));
 }
 
 TEST_CASE("one_hundred_forty_one_yields_CXLI")
 {
-    REQUIRE("CXLI" == roman::convert(141));
+    REQUIRE("CXLI" == roman_numerals::convert(141));
 }
 
 TEST_CASE("one_hundred_sixty_three_yields_CLXIII")
 {
-    REQUIRE("CLXIII" == roman::convert(163));
+    REQUIRE("CLXIII" == roman_numerals::convert(163));
 }
 
 TEST_CASE("four_hundred_two_yields_CDII")
 {
-    REQUIRE("CDII" == roman::convert(402));
+    REQUIRE("CDII" == roman_numerals::convert(402));
 }
 
 TEST_CASE("five_hundred_seventy_five_yields_DLXXV")
 {
-    REQUIRE("DLXXV" == roman::convert(575));
+    REQUIRE("DLXXV" == roman_numerals::convert(575));
 }
 
 TEST_CASE("nine_hundred_eleven_yields_CMXI")
 {
-    REQUIRE("CMXI" == roman::convert(911));
+    REQUIRE("CMXI" == roman_numerals::convert(911));
 }
 
 TEST_CASE("one_thousand_twenty_four_yields_MXXIV")
 {
-    REQUIRE("MXXIV" == roman::convert(1024));
+    REQUIRE("MXXIV" == roman_numerals::convert(1024));
 }
 
 TEST_CASE("three_thousand_yields_MMM")
 {
-    REQUIRE("MMM" == roman::convert(3000));
+    REQUIRE("MMM" == roman_numerals::convert(3000));
 }
 #endif

--- a/exercises/say/say.cpp
+++ b/exercises/say/say.cpp
@@ -1,0 +1,5 @@
+#include "say.h"
+
+namespace say {
+
+}  // namespace say

--- a/exercises/say/say.h
+++ b/exercises/say/say.h
@@ -1,0 +1,8 @@
+#if !defined(SAY_H)
+#define SAY_H
+
+namespace say {
+
+}  // namespace say
+
+#endif // SAY_H

--- a/exercises/scrabble-score/scrabble_score.cpp
+++ b/exercises/scrabble-score/scrabble_score.cpp
@@ -1,0 +1,5 @@
+#include "scrabble_score.h"
+
+namespace scrabble_score {
+
+}  // namespace scrabble_score

--- a/exercises/scrabble-score/scrabble_score.h
+++ b/exercises/scrabble-score/scrabble_score.h
@@ -1,0 +1,8 @@
+#if !defined(SCRABBLE_SCORE_H)
+#define SCRABBLE_SCORE_H
+
+namespace scrabble_score {
+
+}  // namespace scrabble_score
+
+#endif // SCRABBLE_SCORE_H

--- a/exercises/series/series.cpp
+++ b/exercises/series/series.cpp
@@ -1,0 +1,5 @@
+#include "series.h"
+
+namespace series {
+
+}  // namespace series

--- a/exercises/series/series.h
+++ b/exercises/series/series.h
@@ -1,0 +1,8 @@
+#if !defined(SERIES_H)
+#define SERIES_H
+
+namespace series {
+
+}  // namespace series
+
+#endif // SERIES_H

--- a/exercises/sieve/sieve.cpp
+++ b/exercises/sieve/sieve.cpp
@@ -1,0 +1,5 @@
+#include "sieve.h"
+
+namespace sieve {
+
+}  // namespace sieve

--- a/exercises/sieve/sieve.h
+++ b/exercises/sieve/sieve.h
@@ -1,0 +1,8 @@
+#if !defined(SIEVE_H)
+#define SIEVE_H
+
+namespace sieve {
+
+}  // namespace sieve
+
+#endif // SIEVE_H

--- a/exercises/space-age/space_age.cpp
+++ b/exercises/space-age/space_age.cpp
@@ -1,0 +1,5 @@
+#include "space_age.h"
+
+namespace space_age {
+
+}  // namespace space_age

--- a/exercises/space-age/space_age.h
+++ b/exercises/space-age/space_age.h
@@ -1,0 +1,8 @@
+#if !defined(SPACE_AGE_H)
+#define SPACE_AGE_H
+
+namespace space_age {
+
+}  // namespace space_age
+
+#endif // SPACE_AGE_H

--- a/exercises/sum-of-multiples/sum_of_multiples.cpp
+++ b/exercises/sum-of-multiples/sum_of_multiples.cpp
@@ -1,0 +1,5 @@
+#include "sum_of_multiples.h"
+
+namespace sum_of_multiples {
+
+}  // namespace sum_of_multiples

--- a/exercises/sum-of-multiples/sum_of_multiples.h
+++ b/exercises/sum-of-multiples/sum_of_multiples.h
@@ -1,0 +1,8 @@
+#if !defined(SUM_OF_MULTIPLES_H)
+#define SUM_OF_MULTIPLES_H
+
+namespace sum_of_multiples {
+
+}  // namespace sum_of_multiples
+
+#endif // SUM_OF_MULTIPLES_H

--- a/exercises/triangle/triangle.cpp
+++ b/exercises/triangle/triangle.cpp
@@ -1,0 +1,5 @@
+#include "triangle.h"
+
+namespace triangle {
+
+}  // namespace triangle

--- a/exercises/triangle/triangle.h
+++ b/exercises/triangle/triangle.h
@@ -1,0 +1,8 @@
+#if !defined(TRIANGLE_H)
+#define TRIANGLE_H
+
+namespace triangle {
+
+}  // namespace triangle
+
+#endif // TRIANGLE_H

--- a/exercises/trinary/trinary.cpp
+++ b/exercises/trinary/trinary.cpp
@@ -1,0 +1,5 @@
+#include "trinary.h"
+
+namespace trinary {
+
+}  // namespace trinary

--- a/exercises/trinary/trinary.h
+++ b/exercises/trinary/trinary.h
@@ -1,0 +1,8 @@
+#if !defined(TRINARY_H)
+#define TRINARY_H
+
+namespace trinary {
+
+}  // namespace trinary
+
+#endif // TRINARY_H

--- a/exercises/word-count/word_count.cpp
+++ b/exercises/word-count/word_count.cpp
@@ -1,0 +1,5 @@
+#include "word_count.h"
+
+namespace word_count {
+
+}  // namespace word_count

--- a/exercises/word-count/word_count.h
+++ b/exercises/word-count/word_count.h
@@ -1,0 +1,8 @@
+#if !defined(WORD_COUNT_H)
+#define WORD_COUNT_H
+
+namespace word_count {
+
+}  // namespace word_count
+
+#endif // WORD_COUNT_H


### PR DESCRIPTION
This change renames the namespaces so that they always[1] match the exercise name and adds example stubs to every exercise.

[1] Clock can't use the namespace 'clock', so that was unchanged. It conflicts with the stdlib, I'm still not entirely clear why.

Closes #300 