### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  configuration-test:
+    name: Check Configuration
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configlet
+      run: |
+        bin/fetch-configlet
+        bin/configlet lint .
+        bin/check-configlet-fmt.sh
+
+  linux-min:
+    name: Linux Min Config
+    runs-on: ubuntu-16.04
+    strategy:
+      matrix:
+        compiler: [clang++-3.8, g++-5]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      # Boost must be installed only because the CMake version (3.12) can't
+      # detect the installed Boost version (1.69)
+      run: sudo apt-get -y install ninja-build libboost-date-time-dev clang-3.8 g++-5
+    - name: Run tests with common Catch
+      run: |
+        cmake -G Ninja .
+        cmake --build . -- test_hello-world
+        cmake --build .
+      env:
+        CXX: ${{ matrix.compiler }}
+
+  linux-latest:
+    name: Linux Latest Config
+    needs: [linux-min, configuration-test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [clang++, g++]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      # Boost must be installed only because the CMake version (3.12) can't
+      # detect the installed Boost version (1.69)
+      run: sudo apt-get -y install ninja-build libboost-date-time-dev
+    - name: Run tests with common Catch
+      if: matrix.compiler == 'g++'
+      run: |
+        cmake -G Ninja .
+        cmake --build . -- test_hello-world
+        cmake --build .
+      env:
+        CXX: ${{ matrix.compiler }}
+    - name: Run tests without common Catch
+      if: matrix.compiler == 'clang++'
+      run: |
+        cmake -G Ninja -DEXERCISM_COMMON_CATCH=OFF .
+        cmake --build . -- test_hello-world
+        cmake --build .
+      env:
+        CXX: ${{ matrix.compiler }}
+
+  windows:
+    name: Windows
+    needs: [linux-min, configuration-test]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run Tests
+      run: |
+        cmake .
+        cmake --build . -- test_hello-world
+        cmake --build .
+
+  mac:
+    name: MacOS
+    needs: [linux-min, configuration-test]
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Boost
+      run: brew install boost
+    - name: Run Tests
+      run: |
+        cmake .
+        cmake --build . -- test_hello-world
+        cmake --build .
+

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -1,0 +1,28 @@
+name: Hello World
+
+# TODO: Run on all platforms
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'exercises/hello-world/*'
+    - 'bin/check-hello-world.sh'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'exercises/hello-world/*'
+    - 'bin/check-hello-world.sh'
+
+jobs:
+  hello-world-fails:
+    name: Hello World Fails
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Check Hello World Fails
+      run: bin/check-hello-world.sh
+      env:
+        CXX: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(exercism CXX)
 
 set(alt_exercise_tree ${CMAKE_CURRENT_SOURCE_DIR}/build_exercises)
 
-function(travis_fixup exercise_dir alt_exercise_root)
+function(build_fixup exercise_dir alt_exercise_root)
     string(REPLACE "-" "_" file ${exercise_dir})
     set(source ${CMAKE_CURRENT_SOURCE_DIR}/exercises/${exercise_dir})
     if(EXISTS ${source})
@@ -34,6 +34,6 @@ file(GLOB exercise_list ${CMAKE_CURRENT_SOURCE_DIR}/exercises/*)
 
 foreach(exercise_dir ${exercise_list})
     get_filename_component(exercise ${exercise_dir} NAME)
-    travis_fixup(${exercise} ${alt_exercise_tree})
+    build_fixup(${exercise} ${alt_exercise_tree})
     add_subdirectory(${alt_exercise_tree}/${exercise})
 endforeach()

--- a/bin/check-hello-world.sh
+++ b/bin/check-hello-world.sh
@@ -15,7 +15,7 @@ mkdir -p "$hello_world_tmp_dir"
 cd "$hello_world_tmp_dir"
 
 # Configuring should work.
-cmake -G Ninja "$hello_world_dir"
+cmake "$hello_world_dir"
 
 echo "Building hello-world, which should fail."
 

--- a/exercises/armstrong-numbers/example.cpp
+++ b/exercises/armstrong-numbers/example.cpp
@@ -1,8 +1,11 @@
-#include "armstrong_numbers.h"
 #include <cmath>
 
+#include "armstrong_numbers.h"
+
 bool armstrong_numbers::is_armstrong_number(int number) {
-    int length = number != 0 && number != 1 ? std::log10(std::abs(number)) + 1 : 1;
+    int length = number != 0 && number != 1
+                     ? std::log10(std::abs(static_cast<double>(number))) + 1
+                     : 1;
     int accumulate = 0;
     for (int current = number; current != 0; current /= 10) {
         accumulate += std::pow(current % 10, length);


### PR DESCRIPTION
Replaces Travis CI with Github Actions. This change also adds testing on Windows and Mac in addition to Linux.

I could leave in Travis, but this change is already a super-set of Travis functionality.