### PR TITLE
Add links to Boost libraries in exercise READMEs

### DIFF
--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -12,6 +12,10 @@ Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installa
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
+CMake will try to find and configure it for you if it is installed on your system.
+See documentation for on [`boost::posix_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html).
+
 ## Passing the Tests
 
 Get the first test compiling, linking and passing by following the [three

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -14,7 +14,7 @@ environment expected by the exercises.
 
 This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
 CMake will try to find and configure it for you if it is installed on your system.
-See documentation for on [`boost::posix_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html).
+See the documentation for [`boost::posix_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html).
 
 ## Passing the Tests
 

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -33,6 +33,10 @@ Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installa
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
+CMake will try to find and configure it for you if it is installed on your system.
+See for documentation on [`boost::gregorian::date`](https://www.boost.org/doc/libs/1_59_0/doc/html/date_time/gregorian.html#date_time.gregorian.date_class).
+
 ## Passing the Tests
 
 Get the first test compiling, linking and passing by following the [three

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -35,7 +35,7 @@ environment expected by the exercises.
 
 This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
 CMake will try to find and configure it for you if it is installed on your system.
-See for documentation on [`boost::gregorian::date`](https://www.boost.org/doc/libs/1_59_0/doc/html/date_time/gregorian.html#date_time.gregorian.date_class).
+See the documentation for [`boost::gregorian::date`](https://www.boost.org/doc/libs/1_59_0/doc/html/date_time/gregorian.html#date_time.gregorian.date_class).
 
 ## Passing the Tests
 


### PR DESCRIPTION
Gigasecond and Meetup use Boost libraries to handle time functions.
Warn students of this in the README.