### PR TITLE
Bump Travis CI dist to Xenial (16.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: cpp
 os: linux
@@ -43,10 +43,9 @@ matrix:
             - g++-8
 
 before_install:
-  - sudo add-apt-repository -y ppa:samuel-bachmann/boost
   - sudo apt-get -y -d update
 install:
-  - sudo apt-get -y install cmake3 ninja-build libboost-date-time1.60-dev
+  - sudo apt-get -y install cmake ninja-build libboost-date-time-dev
   - export CXX=${COMPILER}
   - ${CXX} --version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 sudo: false
 language: cpp
 os: linux
@@ -6,35 +5,26 @@ os: linux
 matrix:
   include:
     - env: COMPILER=g++-5
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
+      dist: xenial
 
     - env: COMPILER=clang++-3.8
+      dist: xenial
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
           packages:
             - clang-3.8
-            - g++-5
 
     - env:
       - COMPILER=clang++-7
       - EXERCISM_COMMON_CATCH=false
+      dist: bionic
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
           packages:
             - clang-7
 
     - env: COMPILER=g++-8
+      dist: bionic
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 before_install:
   - sudo apt-get -y -d update
 install:
-  - sudo apt-get -y install cmake ninja-build libboost-date-time-dev
+  - sudo apt-get -y install ninja-build libboost-date-time-dev
   - export CXX=${COMPILER}
   - ${CXX} --version
 script:

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -11,7 +11,7 @@ project(${exercise} CXX)
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS date_time)
+find_package(Boost 1.58 REQUIRED COMPONENTS date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -12,9 +12,9 @@ Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installa
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
-This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
+This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_58_0/doc/html/date_time.html) library.
 CMake will try to find and configure it for you if it is installed on your system.
-See the documentation for [`boost::posix_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html).
+See the documentation for [`boost::posix_time`](http://www.boost.org/doc/libs/1_58_0/doc/html/date_time/posix_time.html).
 
 ## Passing the Tests
 

--- a/exercises/gigasecond/gigasecond_test.cpp
+++ b/exercises/gigasecond/gigasecond_test.cpp
@@ -5,7 +5,7 @@
 // This problem requires you to install and use the boost date_time library.
 // CMake will try to find and configure it for you if it is installed on your
 // system.
-// See <http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html>
+// See <http://www.boost.org/doc/libs/1_58_0/doc/html/date_time/posix_time.html>
 // for documentation on boost::posix_time
 
 using namespace boost::posix_time;

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -11,7 +11,7 @@ project(${exercise} CXX)
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.59 REQUIRED COMPONENTS date_time)
+find_package(Boost 1.58 REQUIRED COMPONENTS date_time)
 
 # Get a source filename from the exercise name by replacing -'s with _'s
 string(REPLACE "-" "_" file ${exercise})

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -33,9 +33,9 @@ Make sure you have read the [Installing](https://exercism.io/tracks/cpp/installa
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
-This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html) library.
+This problem requires you to install and use the Boost [`date_time`](http://www.boost.org/doc/libs/1_58_0/doc/html/date_time.html) library.
 CMake will try to find and configure it for you if it is installed on your system.
-See the documentation for [`boost::gregorian::date`](https://www.boost.org/doc/libs/1_59_0/doc/html/date_time/gregorian.html#date_time.gregorian.date_class).
+See the documentation for [`boost::gregorian::date`](https://www.boost.org/doc/libs/1_58_0/doc/html/date_time/gregorian.html#date_time.gregorian.date_class).
 
 ## Passing the Tests
 

--- a/exercises/meetup/meetup_test.cpp
+++ b/exercises/meetup/meetup_test.cpp
@@ -5,7 +5,7 @@
 // This problem requires you to install and use the boost date_time library.
 // CMake will try to find and configure it for you if it is installed on your
 // system.
-// See <http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html> for
+// See <http://www.boost.org/doc/libs/1_58_0/doc/html/date_time.html> for
 // documentation on boost::gregorian::date
 
 TEST_CASE("monteenth_of_May_2013")


### PR DESCRIPTION
This bump lets us test directly on our minimum supported version, and
removes the workarounds put in place for supporting Trusty (14.04)

Closes #323 