### PR TITLE
Modify fetch-configlet script

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-LATEST=https://github.com/exercism/configlet/releases/latest
-
 OS=$(
 case $(uname) in
     (Darwin*)
@@ -26,7 +24,9 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+LATEST="$(curl -s https://api.github.com/repos/exercism/configlet/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')"
+URL=https://github.com/exercism/configlet/releases/download/$LATEST/configlet-$OS-${ARCH}.tgz
+
+echo $URL
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
https://github.com/exercism/configlet/issues/173: Travis CI are fails because of fetch-configlet script failure while getting latest release URL. As described in https://github.com/exercism/haskell/pull/898#pullrequestreview-368719612 the problem was that  `curl` started to output headers in lowercase

Few days ago I was created PR which simply fixed the case (https://github.com/exercism/cpp/pull/344)

This PR provides possibility to get latest release of configlet script using GitHub API.


