### PR TITLE
fetch-configlet: Pull upstream changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         bin/fetch-configlet
         bin/configlet lint .
         bin/check-configlet-fmt.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   linux-min:
     name: Linux Min Config

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,32 +1,52 @@
 #!/bin/bash
 
-OS=$(
-case $(uname) in
-    (Darwin*)
-        echo "mac";;
-    (Linux*)
-        echo "linux";;
-    (Windows*)
-        echo "windows";;
-    (*)
-        echo "linux";;
-esac)
+set -eo pipefail
 
-ARCH=$(
-case $(uname -m) in
-    (*64*)
-        echo 64bit;;
-    (*686*)
-        echo 32bit;;
-    (*386*)
-        echo 32bit;;
-    (*)
-        echo 64bit;;
-esac)
+readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'
 
-LATEST="$(curl -s https://api.github.com/repos/exercism/configlet/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')"
-URL=https://github.com/exercism/configlet/releases/download/$LATEST/configlet-$OS-${ARCH}.tgz
+case "$(uname)" in
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
+esac
 
-echo $URL
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
 
-curl -s --location $URL | tar xz -C bin/
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+if [ -z "${GITHUB_TOKEN}" ]
+then
+    HEADER=''
+else
+    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+fi
+
+FILENAME="configlet-${OS}-${ARCH}.${EXT}"
+
+get_url () {
+    curl --header "$HEADER" -s "$LATEST" |
+        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
+        tr -d '"'
+}
+
+URL=$(get_url)
+
+case "$EXT" in
+    (*zip)
+        curl --header "$HEADER" -s --location "$URL" -o bin/latest-configlet.zip
+        unzip bin/latest-configlet.zip -d bin/
+        rm bin/latest-configlet.zip
+        ;;
+    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
+esac

--- a/bin/fetch-configlet.ps1
+++ b/bin/fetch-configlet.ps1
@@ -1,0 +1,24 @@
+Function DownloadUrl ([string] $FileName, $Headers) {
+    $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
+}
+
+Function Headers {
+    If ($GITHUB_TOKEN) { @{ Authorization = "Bearer ${GITHUB_TOKEN}" } } Else { @{ } }
+}
+
+Function Arch {
+    If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+}
+
+$arch = Arch
+$headers = Headers
+$fileName = "configlet-windows-$arch.zip"
+$outputDirectory = "bin"
+$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+$zipUrl = DownloadUrl -FileName $fileName -Headers $headers
+
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile
+Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
+Remove-Item -Path $outputFile


### PR DESCRIPTION
Updates our version of fetch-configlet to the latest version in the configlet repo. See https://github.com/exercism/configlet/pull/174 for context.