### PR TITLE
Add test for double and integer argumetns

### DIFF
--- a/exercises/triangle/triangle_test.cpp
+++ b/exercises/triangle/triangle_test.cpp
@@ -72,4 +72,9 @@ TEST_CASE("larger_triangles_violating_triangle_inequality_are_illegal")
 {
     REQUIRE_THROWS_AS(triangle::kind(7, 3, 2), std::domain_error);
 }
+
+TEST_CASE("double_and_integer_arguments")
+{
+    REQUIRE(triangle::flavor::scalene == triangle::kind(5.5, 4, 2));
+}
 #endif


### PR DESCRIPTION
Some solutions use templates, and this test won't compile if they have just one template argument.

A sample compilation error:
no matching function for call to ‘kind(double, int, int)’