### PR TITLE
Use cmake for debug symbols

### DIFF
--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/acronym/CMakeLists.txt
+++ b/exercises/acronym/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/all-your-base/CMakeLists.txt
+++ b/exercises/all-your-base/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/allergies/CMakeLists.txt
+++ b/exercises/allergies/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/armstrong-numbers/CMakeLists.txt
+++ b/exercises/armstrong-numbers/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/armstrong-numbers/CMakeLists.txt
+++ b/exercises/armstrong-numbers/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/atbash-cipher/CMakeLists.txt
+++ b/exercises/atbash-cipher/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/binary-search-tree/CMakeLists.txt
+++ b/exercises/binary-search-tree/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/binary-search-tree/CMakeLists.txt
+++ b/exercises/binary-search-tree/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/binary-search/CMakeLists.txt
+++ b/exercises/binary-search/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/binary-search/CMakeLists.txt
+++ b/exercises/binary-search/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/circular-buffer/CMakeLists.txt
+++ b/exercises/circular-buffer/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/circular-buffer/CMakeLists.txt
+++ b/exercises/circular-buffer/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/collatz-conjecture/CMakeLists.txt
+++ b/exercises/collatz-conjecture/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/collatz-conjecture/CMakeLists.txt
+++ b/exercises/collatz-conjecture/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/complex-numbers/CMakeLists.txt
+++ b/exercises/complex-numbers/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/complex-numbers/CMakeLists.txt
+++ b/exercises/complex-numbers/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -40,7 +40,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -38,6 +38,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/isogram/CMakeLists.txt
+++ b/exercises/isogram/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/luhn/CMakeLists.txt
+++ b/exercises/luhn/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/luhn/CMakeLists.txt
+++ b/exercises/luhn/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/matching-brackets/CMakeLists.txt
+++ b/exercises/matching-brackets/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/matching-brackets/CMakeLists.txt
+++ b/exercises/matching-brackets/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -40,7 +40,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -38,6 +38,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/pangram/CMakeLists.txt
+++ b/exercises/pangram/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/pascals-triangle/CMakeLists.txt
+++ b/exercises/pascals-triangle/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/pascals-triangle/CMakeLists.txt
+++ b/exercises/pascals-triangle/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/protein-translation/CMakeLists.txt
+++ b/exercises/protein-translation/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/protein-translation/CMakeLists.txt
+++ b/exercises/protein-translation/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/reverse-string/CMakeLists.txt
+++ b/exercises/reverse-string/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/robot-simulator/CMakeLists.txt
+++ b/exercises/robot-simulator/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/robot-simulator/CMakeLists.txt
+++ b/exercises/robot-simulator/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/secret-handshake/CMakeLists.txt
+++ b/exercises/secret-handshake/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/secret-handshake/CMakeLists.txt
+++ b/exercises/secret-handshake/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/two-fer/CMakeLists.txt
+++ b/exercises/two-fer/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/two-fer/CMakeLists.txt
+++ b/exercises/two-fer/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(${exercise} PROPERTIES
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -g"
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
 endif()
 

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -32,6 +32,8 @@ set_target_properties(${exercise} PROPERTIES
     CXX_EXTENSIONS OFF
 )
 
+set(CMAKE_BUILD_TYPE Debug)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"


### PR DESCRIPTION
This should work better than the -g flag. Also has the benefit of removing optimization flags, allowing faster compilation = faster iterations.