### PR TITLE
binary-search-tree: Add missing include.

### DIFF
--- a/exercises/binary-search-tree/example.h
+++ b/exercises/binary-search-tree/example.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <cstdint>
 #include <utility>
+#include <stdexcept>
 
 namespace binary_search_tree
 {


### PR DESCRIPTION
Adds a missing include that is causing a test failure in the clang-latest tests.