### PR TITLE
Add script to fetch canonical data syncer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 tmp
 bin/configlet
 bin/configlet.exe
+bin/canonical_data_syncer
+bin/canonical_data_syncer.exe
 CMakeCache.txt
 CMakeFiles/
 Makefile

--- a/bin/fetch-canonical_data_syncer
+++ b/bin/fetch-canonical_data_syncer
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eo pipefail
+
+readonly LATEST='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+
+case "$(uname)" in
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
+esac
+
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+if [ -z "${GITHUB_TOKEN}" ]
+then
+    HEADER=''
+else
+    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+fi
+
+FILENAME="canonical_data_syncer-${OS}-${ARCH}.${EXT}"
+
+get_url () {
+    curl --header "$HEADER" -s "$LATEST" |
+        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
+        tr -d '"'
+}
+
+URL=$(get_url)
+
+case "$EXT" in
+    (*zip)
+        curl --header "$HEADER" -s --location "$URL" -o bin/latest-canonical_data_syncer.zip
+        unzip bin/latest-canonical_data_syncer.zip -d bin/
+        rm bin/latest-canonical_data_syncer.zip
+        ;;
+    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
+esac

--- a/bin/fetch-canonical_data_syncer.ps1
+++ b/bin/fetch-canonical_data_syncer.ps1
@@ -1,0 +1,24 @@
+Function DownloadUrl ([string] $FileName, $Headers) {
+    $latestUrl = "https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest"
+    $json = Invoke-RestMethod -Headers $Headers -Uri $latestUrl
+    $json.assets | Where-Object { $_.browser_download_url -match $FileName } | Select-Object -ExpandProperty browser_download_url
+}
+
+Function Headers {
+    If ($GITHUB_TOKEN) { @{ Authorization = "Bearer ${GITHUB_TOKEN}" } } Else { @{ } }
+}
+
+Function Arch {
+    If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+}
+
+$arch = Arch
+$headers = Headers
+$fileName = "canonical_data_syncer-windows-$arch.zip"
+$outputDirectory = "bin"
+$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
+$zipUrl = DownloadUrl -FileName $fileName -Headers $headers
+
+Invoke-WebRequest -Headers $headers -Uri $zipUrl -OutFile $outputFile
+Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
+Remove-Item -Path $outputFile


### PR DESCRIPTION
Used to help keep the exercise-specific `tests.toml` files in sync with the latest canonical data in the problem-specifications repo. Per #362 

See https://github.com/exercism/canonical-data-syncer for how to use it.