### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -1,1 +1,3 @@
+# About
+
 TODO: add information on strings concept

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 TODO: the content below is copied from the exercise introduction and probably needs rewriting to a proper concept introduction
 
 A `string` in C++ is a mutable object that represents text as a sequence of Unicode characters (letters, digits, punctuation, etc.). Strings are manipulated by calling the string's methods.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [C++](https://en.wikipedia.org/wiki/C%2B%2B) (pronounced cee plus plus) is a general purpose programming language developed by [Bjarne Stroustrup](https://en.wikipedia.org/wiki/Bjarne_Stroustrup) starting in 1979 at Bell Labs. It is  immensely  popular,  particularly for  applications  that  require  speed  and/or  access to  some low-level  features.  It is considered to be an intermediate level language, as it encapsulates both high and low level language features.
 
 C++ supports [procedural](https://en.wikipedia.org/wiki/Procedural_programming), [object-oriented](https://en.wikipedia.org/wiki/Object-oriented_programming), [functional](https://en.wikipedia.org/wiki/Functional_programming) and [generic](https://en.wikipedia.org/wiki/Generic_programming) programming. Compilers for C++ are available for essentially every platform, including Windows, Mac OS, and Linux.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ## Prerequisites
 
 The C++ language track requires that you have the following software

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Learning C++ From Ground Zero
 
 C++ is a language with a broad, expressive syntax that supports several

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 - [C++ Reference](http://en.cppreference.com/w/): An online reference for C and C++ programming languages. You have a doubt what a method does or what's the interface for a STL's data structure? cppreference.com got you covered.
 - [The Definitive C++ Book Guide and List](https://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list): The legendary StackOverflow's question about C++ books.
 - [`c++-faq` tag on StackOverflow](https://stackoverflow.com/tags/c%2b%2b-faq/info)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Each exercise supplies the unit tests and a CMake build recipe.  You
 provide the implementation.
 Each test file is meant to link against your implementation to provide a

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -20,7 +20,7 @@ Working through each exercise is a process of:
   * Refactor your implementation to enhance readability, reduce duplication, etc.
   * Uncomment the next test
 
-### Creating the Initial Build with CMake
+## Creating the Initial Build with CMake
 
 Each exercise will bring a `CMakeLists.txt` file along with the unit
 tests.  It contains the canned CMake recipe to handle the build for you.
@@ -57,7 +57,7 @@ code using the appropriate command for your environment:
 
 Examples of running CMake for different environments are shown below.
 
-#### Linux\MacOS with Make
+### Linux\MacOS with Make
 
 The generator name for CMake is `Unix Makefiles`.
 Assuming the current exercise is `bob` and we're in the exercise folder:
@@ -77,14 +77,14 @@ Simply type `make` in the build directory to compile the tests. This should
 generate compile time errors. Once the errors are fixed, `make` will build and 
 run the tests.
 
-#### Windows with Visual Studio
+### Windows with Visual Studio
 
 Visual Studio has native support for CMake projects, so you should not need to
 install CMake separately or run it outside of Visual Studio. Follow
 [this guide](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio)
 to setup the CMake project in Visual Studio.
 
-#### MacOS with Xcode
+### MacOS with Xcode
 
 The generator name for CMake is `Xcode`.
 Assuming the current exercise is `bob` and we're in the exercise folder:

--- a/exercises/concept/strings/.docs/after.md
+++ b/exercises/concept/strings/.docs/after.md
@@ -1,3 +1,5 @@
+# After
+
 The key thing to remember about C++ strings is that they are mutable objects representing text as a sequence of Unicode characters (letters, digits, punctuation, etc.).
 
 Manipulating a string can be be done by calling one of its [methods][methods]. C++ strings are not immutable and their value can be changed after definition.

--- a/exercises/concept/strings/.docs/hints.md
+++ b/exercises/concept/strings/.docs/hints.md
@@ -1,3 +1,5 @@
+# Hints
+
 ## General
 
 - [This tutorial][strings-tutorial] offers a nice introduction to C++ strings.

--- a/exercises/concept/strings/.docs/instructions.md
+++ b/exercises/concept/strings/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you'll be processing log-lines.
 
 Each log line is a string formatted as follows: `"[<LEVEL>]: <MESSAGE>"`.

--- a/exercises/concept/strings/.docs/introduction.md
+++ b/exercises/concept/strings/.docs/introduction.md
@@ -1,1 +1,3 @@
+# Introduction
+
 A `string` in C++ is a mutable object that represents text as a sequence of Unicode characters (letters, digits, punctuation, etc.). Strings are manipulated by calling the string's methods.

--- a/exercises/concept/strings/.meta/design.md
+++ b/exercises/concept/strings/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics of the Concept of Strings in [C++][docs.string].


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
