### PR TITLE
🤖 Update tests.toml files to latest spec

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# basic
-"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+include = true
 
-# lowercase words
-"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+include = true
 
-# punctuation
-"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+include = true
 
-# all caps word
-"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+include = true
 
-# punctuation without whitespace
-"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+include = true
 
-# very long abbreviation
-"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+include = true
 
-# consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+include = true
 
-# apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+include = true
 
-# underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"
+include = true

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -1,64 +1,87 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single bit one to decimal
-"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+[5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
+description = "single bit one to decimal"
+include = true
 
-# binary to single decimal
-"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+[0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
+description = "binary to single decimal"
+include = true
 
-# single decimal to binary
-"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+[f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
+description = "single decimal to binary"
+include = true
 
-# binary to multiple decimal
-"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+[2c45cf54-6da3-4748-9733-5a3c765d925b]
+description = "binary to multiple decimal"
+include = true
 
-# decimal to binary
-"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+[65ddb8b4-8899-4fcc-8618-181b2cf0002d]
+description = "decimal to binary"
+include = true
 
-# trinary to hexadecimal
-"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+[8d418419-02a7-4824-8b7a-352d33c6987e]
+description = "trinary to hexadecimal"
+include = true
 
-# hexadecimal to trinary
-"d3901c80-8190-41b9-bd86-38d988efa956" = true
+[d3901c80-8190-41b9-bd86-38d988efa956]
+description = "hexadecimal to trinary"
+include = true
 
-# 15-bit integer
-"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+[5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
+description = "15-bit integer"
+include = true
 
-# empty list
-"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+[d68788f7-66dd-43f8-a543-f15b6d233f83]
+description = "empty list"
+include = true
 
-# single zero
-"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+[5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
+description = "single zero"
+include = true
 
-# multiple zeros
-"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+[2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
+description = "multiple zeros"
+include = true
 
-# leading zeros
-"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+[3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
+description = "leading zeros"
+include = true
 
-# input base is one
-"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+[a6b476a1-1901-4f2a-92c4-4d91917ae023]
+description = "input base is one"
+include = true
 
-# input base is zero
-"e21a693a-7a69-450b-b393-27415c26a016" = true
+[e21a693a-7a69-450b-b393-27415c26a016]
+description = "input base is zero"
+include = true
 
-# input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+[54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
+description = "input base is negative"
+include = true
 
-# negative digit
-"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+[9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
+description = "negative digit"
+include = true
 
-# invalid positive digit
-"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+[232fa4a5-e761-4939-ba0c-ed046cd0676a]
+description = "invalid positive digit"
+include = true
 
-# output base is one
-"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+[14238f95-45da-41dc-95ce-18f860b30ad3]
+description = "output base is one"
+include = true
 
-# output base is zero
-"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+[73dac367-da5c-4a37-95fe-c87fad0a4047]
+description = "output base is zero"
+include = true
 
-# output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+[13f81f42-ff53-4e24-89d9-37603a48ebd9]
+description = "output base is negative"
+include = true
 
-# both bases are negative
-"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true
+[0e6c895d-8a5d-4868-a345-309d094cfe8d]
+description = "both bases are negative"
+include = true

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,148 +1,199 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# not allergic to anything
-"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "not allergic to anything"
+include = true
 
-# allergic only to eggs
-"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "allergic only to eggs"
+include = true
 
-# allergic to eggs and something else
-"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "allergic to eggs and something else"
+include = true
 
-# allergic to something, but not eggs
-"64a6a83a-5723-4b5b-a896-663307403310" = true
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "allergic to something, but not eggs"
+include = true
 
-# allergic to everything
-"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "not allergic to anything"
+include = true
 
-# allergic only to peanuts
-"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "allergic only to peanuts"
+include = true
 
-# allergic to peanuts and something else
-"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "allergic to peanuts and something else"
+include = true
 
-# allergic to something, but not peanuts
-"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "allergic to something, but not peanuts"
+include = true
 
-# allergic to everything
-"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "not allergic to anything"
+include = true
 
-# allergic only to shellfish
-"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "allergic only to shellfish"
+include = true
 
-# allergic to shellfish and something else
-"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "allergic to shellfish and something else"
+include = true
 
-# allergic to something, but not shellfish
-"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "allergic to something, but not shellfish"
+include = true
 
-# allergic to everything
-"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "not allergic to anything"
+include = true
 
-# allergic only to strawberries
-"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "allergic only to strawberries"
+include = true
 
-# allergic to strawberries and something else
-"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "allergic to strawberries and something else"
+include = true
 
-# allergic to something, but not strawberries
-"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "allergic to something, but not strawberries"
+include = true
 
-# allergic to everything
-"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "not allergic to anything"
+include = true
 
-# allergic only to tomatoes
-"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "allergic only to tomatoes"
+include = true
 
-# allergic to tomatoes and something else
-"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "allergic to tomatoes and something else"
+include = true
 
-# allergic to something, but not tomatoes
-"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "allergic to something, but not tomatoes"
+include = true
 
-# allergic to everything
-"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"978467ab-bda4-49f7-b004-1d011ead947c" = true
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "not allergic to anything"
+include = true
 
-# allergic only to chocolate
-"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "allergic only to chocolate"
+include = true
 
-# allergic to chocolate and something else
-"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "allergic to chocolate and something else"
+include = true
 
-# allergic to something, but not chocolate
-"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "allergic to something, but not chocolate"
+include = true
 
-# allergic to everything
-"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "not allergic to anything"
+include = true
 
-# allergic only to pollen
-"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "allergic only to pollen"
+include = true
 
-# allergic to pollen and something else
-"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "allergic to pollen and something else"
+include = true
 
-# allergic to something, but not pollen
-"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "allergic to something, but not pollen"
+include = true
 
-# allergic to everything
-"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "not allergic to anything"
+include = true
 
-# allergic only to cats
-"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "allergic only to cats"
+include = true
 
-# allergic to cats and something else
-"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "allergic to cats and something else"
+include = true
 
-# allergic to something, but not cats
-"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "allergic to something, but not cats"
+include = true
 
-# allergic to everything
-"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "allergic to everything"
+include = true
 
-# no allergies
-"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "no allergies"
+include = true
 
-# just eggs
-"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "just eggs"
+include = true
 
-# just peanuts
-"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "just peanuts"
+include = true
 
-# just strawberries
-"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "just strawberries"
+include = true
 
-# eggs and peanuts
-"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "eggs and peanuts"
+include = true
 
-# more than eggs but not peanuts
-"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "more than eggs but not peanuts"
+include = true
 
-# lots of stuff
-"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "lots of stuff"
+include = true
 
-# everything
-"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "everything"
+include = true
 
-# no allergen score parts
-"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "no allergen score parts"
+include = true

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,43 +1,59 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no matches
-"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+include = true
 
-# detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+include = true
 
-# does not detect anagram subsets
-"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+include = true
 
-# detects anagram
-"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+include = true
 
-# detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = true
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+include = true
 
-# detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = true
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+include = true
 
-# does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+include = true
 
-# detects anagrams case-insensitively
-"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+include = true
 
-# detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+include = true
 
-# detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = true
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+include = true
 
-# does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+include = true
 
-# anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+include = true
 
-# words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = true
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+include = true
 
-# words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = true
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"
+include = true

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Zero is an Armstrong number
-"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = true
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+include = true
 
-# Single digit numbers are Armstrong numbers
-"579e8f03-9659-4b85-a1a2-d64350f6b17a" = true
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
+include = true
 
-# There are no 2 digit Armstrong numbers
-"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = true
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
+include = true
 
-# Three digit number that is an Armstrong number
-"509c087f-e327-4113-a7d2-26a4e9d18283" = true
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
+include = true
 
-# Three digit number that is not an Armstrong number
-"7154547d-c2ce-468d-b214-4cb953b870cf" = true
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
+include = true
 
-# Four digit number that is an Armstrong number
-"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = true
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
+include = true
 
-# Four digit number that is not an Armstrong number
-"eed4b331-af80-45b5-a80b-19c9ea444b2e" = true
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
+include = true
 
-# Seven digit number that is an Armstrong number
-"f971ced7-8d68-4758-aea1-d4194900b864" = true
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
+include = true
 
-# Seven digit number that is not an Armstrong number
-"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = true
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"
+include = true

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,59 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode yes"
+include = true
 
-# encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode no"
+include = true
 
-# encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode OMG"
+include = true
 
-# encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode spaces"
+include = true
 
-# encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode mindblowingly"
+include = true
 
-# encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode numbers"
+include = true
 
-# encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode deep thought"
+include = true
 
-# encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode all the letters"
+include = true
 
-# decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode exercism"
+include = true
 
-# decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode a sentence"
+include = true
 
-# decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = true
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode numbers"
+include = true
 
-# decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode all the letters"
+include = true
 
-# decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode with too many spaces"
+include = true
 
-# decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode with no spaces"
+include = true

--- a/exercises/practice/beer-song/.meta/tests.toml
+++ b/exercises/practice/beer-song/.meta/tests.toml
@@ -1,25 +1,35 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# first generic verse
-"5a02fd08-d336-4607-8006-246fe6fa9fb0" = true
+[5a02fd08-d336-4607-8006-246fe6fa9fb0]
+description = "first generic verse"
+include = true
 
-# last generic verse
-"77299ca6-545e-4217-a9cc-606b342e0187" = true
+[77299ca6-545e-4217-a9cc-606b342e0187]
+description = "last generic verse"
+include = true
 
-# verse with 2 bottles
-"102cbca0-b197-40fd-b548-e99609b06428" = true
+[102cbca0-b197-40fd-b548-e99609b06428]
+description = "verse with 2 bottles"
+include = true
 
-# verse with 1 bottle
-"b8ef9fce-960e-4d85-a0c9-980a04ec1972" = true
+[b8ef9fce-960e-4d85-a0c9-980a04ec1972]
+description = "verse with 1 bottle"
+include = true
 
-# verse with 0 bottles
-"c59d4076-f671-4ee3-baaa-d4966801f90d" = true
+[c59d4076-f671-4ee3-baaa-d4966801f90d]
+description = "verse with 0 bottles"
+include = true
 
-# first two verses
-"7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e" = true
+[7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e]
+description = "first two verses"
+include = true
 
-# last three verses
-"949868e7-67e8-43d3-9bb4-69277fe020fb" = true
+[949868e7-67e8-43d3-9bb4-69277fe020fb]
+description = "last three verses"
+include = true
 
-# all verses
-"bc220626-126c-4e72-8df4-fddfc0c3e458" = true
+[bc220626-126c-4e72-8df4-fddfc0c3e458]
+description = "all verses"
+include = true

--- a/exercises/practice/binary-search-tree/.meta/tests.toml
+++ b/exercises/practice/binary-search-tree/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# data is retained
-"e9c93a78-c536-4750-a336-94583d23fafa" = true
+[e9c93a78-c536-4750-a336-94583d23fafa]
+description = "data is retained"
+include = true
 
-# smaller number at left node
-"7a95c9e8-69f6-476a-b0c4-4170cb3f7c91" = true
+[7a95c9e8-69f6-476a-b0c4-4170cb3f7c91]
+description = "smaller number at left node"
+include = true
 
-# same number at left node
-"22b89499-9805-4703-a159-1a6e434c1585" = true
+[22b89499-9805-4703-a159-1a6e434c1585]
+description = "same number at left node"
+include = true
 
-# greater number at right node
-"2e85fdde-77b1-41ed-b6ac-26ce6b663e34" = true
+[2e85fdde-77b1-41ed-b6ac-26ce6b663e34]
+description = "greater number at right node"
+include = true
 
-# can create complex tree
-"dd898658-40ab-41d0-965e-7f145bf66e0b" = true
+[dd898658-40ab-41d0-965e-7f145bf66e0b]
+description = "can create complex tree"
+include = true
 
-# can sort single number
-"9e0c06ef-aeca-4202-b8e4-97f1ed057d56" = true
+[9e0c06ef-aeca-4202-b8e4-97f1ed057d56]
+description = "can sort single number"
+include = true
 
-# can sort if second number is smaller than first
-"425e6d07-fceb-4681-a4f4-e46920e380bb" = true
+[425e6d07-fceb-4681-a4f4-e46920e380bb]
+description = "can sort if second number is smaller than first"
+include = true
 
-# can sort if second number is same as first
-"bd7532cc-6988-4259-bac8-1d50140079ab" = true
+[bd7532cc-6988-4259-bac8-1d50140079ab]
+description = "can sort if second number is same as first"
+include = true
 
-# can sort if second number is greater than first
-"b6d1b3a5-9d79-44fd-9013-c83ca92ddd36" = true
+[b6d1b3a5-9d79-44fd-9013-c83ca92ddd36]
+description = "can sort if second number is greater than first"
+include = true
 
-# can sort complex tree
-"d00ec9bd-1288-4171-b968-d44d0808c1c8" = true
+[d00ec9bd-1288-4171-b968-d44d0808c1c8]
+description = "can sort complex tree"
+include = true

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# finds a value in an array with one element
-"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
+include = true
 
-# finds a value in the middle of an array
-"73469346-b0a0-4011-89bf-989e443d503d" = true
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
+include = true
 
-# finds a value at the beginning of an array
-"327bc482-ab85-424e-a724-fb4658e66ddb" = true
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
+include = true
 
-# finds a value at the end of an array
-"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
+include = true
 
-# finds a value in an array of odd length
-"f0068905-26e3-4342-856d-ad153cadb338" = true
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
+include = true
 
-# finds a value in an array of even length
-"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
+include = true
 
-# identifies that a value is not included in the array
-"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
+include = true
 
-# a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
+include = true
 
-# a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
+include = true
 
-# nothing is found in an empty array
-"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
+include = true
 
-# nothing is found when the left and right bounds cross
-"2c353967-b56d-40b8-acff-ce43115eed64" = true
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"
+include = true

--- a/exercises/practice/binary/.meta/tests.toml
+++ b/exercises/practice/binary/.meta/tests.toml
@@ -1,46 +1,63 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# binary 0 is decimal 0
-"567fc71e-1013-4915-9285-bca0648c0844" = true
+[567fc71e-1013-4915-9285-bca0648c0844]
+description = "binary 0 is decimal 0"
+include = true
 
-# binary 1 is decimal 1
-"c0824fb1-6a0a-4e9a-a262-c6c00af99fa8" = true
+[c0824fb1-6a0a-4e9a-a262-c6c00af99fa8]
+description = "binary 1 is decimal 1"
+include = true
 
-# binary 10 is decimal 2
-"4d2834fb-3cc3-4159-a8fd-da1098def8ed" = true
+[4d2834fb-3cc3-4159-a8fd-da1098def8ed]
+description = "binary 10 is decimal 2"
+include = true
 
-# binary 11 is decimal 3
-"b7b2b649-4a7c-4808-9eb9-caf00529bac6" = true
+[b7b2b649-4a7c-4808-9eb9-caf00529bac6]
+description = "binary 11 is decimal 3"
+include = true
 
-# binary 100 is decimal 4
-"de761aff-73cd-43c1-9e1f-0417f07b1e4a" = true
+[de761aff-73cd-43c1-9e1f-0417f07b1e4a]
+description = "binary 100 is decimal 4"
+include = true
 
-# binary 1001 is decimal 9
-"7849a8f7-f4a1-4966-963e-503282d6814c" = true
+[7849a8f7-f4a1-4966-963e-503282d6814c]
+description = "binary 1001 is decimal 9"
+include = true
 
-# binary 11010 is decimal 26
-"836a101c-aecb-473b-ba78-962408dcda98" = true
+[836a101c-aecb-473b-ba78-962408dcda98]
+description = "binary 11010 is decimal 26"
+include = true
 
-# binary 10001101000 is decimal 1128
-"1c6822a4-8584-438b-8dd4-40f0f0b66371" = true
+[1c6822a4-8584-438b-8dd4-40f0f0b66371]
+description = "binary 10001101000 is decimal 1128"
+include = true
 
-# binary ignores leading zeros
-"91ffe632-8374-4016-b1d1-d8400d9f940d" = true
+[91ffe632-8374-4016-b1d1-d8400d9f940d]
+description = "binary ignores leading zeros"
+include = true
 
-# 2 is not a valid binary digit
-"44f7d8b1-ddc3-4751-8be3-700a538b421c" = true
+[44f7d8b1-ddc3-4751-8be3-700a538b421c]
+description = "2 is not a valid binary digit"
+include = true
 
-# a number containing a non-binary digit is invalid
-"c263a24d-6870-420f-b783-628feefd7b6e" = true
+[c263a24d-6870-420f-b783-628feefd7b6e]
+description = "a number containing a non-binary digit is invalid"
+include = true
 
-# a number with trailing non-binary characters is invalid
-"8d81305b-0502-4a07-bfba-051c5526d7f2" = true
+[8d81305b-0502-4a07-bfba-051c5526d7f2]
+description = "a number with trailing non-binary characters is invalid"
+include = true
 
-# a number with leading non-binary characters is invalid
-"a7f79b6b-039a-4d42-99b4-fcee56679f03" = true
+[a7f79b6b-039a-4d42-99b4-fcee56679f03]
+description = "a number with leading non-binary characters is invalid"
+include = true
 
-# a number with internal non-binary characters is invalid
-"9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e" = true
+[9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e]
+description = "a number with internal non-binary characters is invalid"
+include = true
 
-# a number and a word whitespace separated is invalid
-"46c8dd65-0c32-4273-bb0d-f2b111bccfbd" = true
+[46c8dd65-0c32-4273-bb0d-f2b111bccfbd]
+description = "a number and a word whitespace separated is invalid"
+include = true

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,76 +1,103 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# stating something
-"e162fead-606f-437a-a166-d051915cea8e" = true
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+include = true
 
-# shouting
-"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+include = true
 
-# shouting gibberish
-"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+include = true
 
-# asking a question
-"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+include = true
 
-# asking a numeric question
-"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+include = true
 
-# asking gibberish
-"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+include = true
 
-# talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+include = true
 
-# using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+include = true
 
-# forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+include = true
 
-# shouting numbers
-"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+include = true
 
-# no letters
-"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+include = true
 
-# question with no letters
-"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+include = true
 
-# shouting with special characters
-"496143c8-1c31-4c01-8a08-88427af85c66" = true
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+include = true
 
-# shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+include = true
 
-# statement containing question mark
-"aa8097cc-c548-4951-8856-14a404dd236a" = true
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+include = true
 
-# non-letters with question
-"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+include = true
 
-# prattling on
-"8608c508-f7de-4b17-985b-811878b3cf45" = true
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+include = true
 
-# silence
-"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+include = true
 
-# prolonged silence
-"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+include = true
 
-# alternate silence
-"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+include = true
 
-# multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+include = true
 
-# starting with whitespace
-"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+include = true
 
-# ending with whitespace
-"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+include = true
 
-# other whitespace
-"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+include = true
 
-# non-question ending with whitespace
-"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"
+include = true

--- a/exercises/practice/circular-buffer/.meta/tests.toml
+++ b/exercises/practice/circular-buffer/.meta/tests.toml
@@ -1,43 +1,59 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# reading empty buffer should fail
-"28268ed4-4ff3-45f3-820e-895b44d53dfa" = true
+[28268ed4-4ff3-45f3-820e-895b44d53dfa]
+description = "reading empty buffer should fail"
+include = true
 
-# can read an item just written
-"2e6db04a-58a1-425d-ade8-ac30b5f318f3" = true
+[2e6db04a-58a1-425d-ade8-ac30b5f318f3]
+description = "can read an item just written"
+include = true
 
-# each item may only be read once
-"90741fe8-a448-45ce-be2b-de009a24c144" = true
+[90741fe8-a448-45ce-be2b-de009a24c144]
+description = "each item may only be read once"
+include = true
 
-# items are read in the order they are written
-"be0e62d5-da9c-47a8-b037-5db21827baa7" = true
+[be0e62d5-da9c-47a8-b037-5db21827baa7]
+description = "items are read in the order they are written"
+include = true
 
-# full buffer can't be written to
-"2af22046-3e44-4235-bfe6-05ba60439d38" = true
+[2af22046-3e44-4235-bfe6-05ba60439d38]
+description = "full buffer can't be written to"
+include = true
 
-# a read frees up capacity for another write
-"547d192c-bbf0-4369-b8fa-fc37e71f2393" = true
+[547d192c-bbf0-4369-b8fa-fc37e71f2393]
+description = "a read frees up capacity for another write"
+include = true
 
-# read position is maintained even across multiple writes
-"04a56659-3a81-4113-816b-6ecb659b4471" = true
+[04a56659-3a81-4113-816b-6ecb659b4471]
+description = "read position is maintained even across multiple writes"
+include = true
 
-# items cleared out of buffer can't be read
-"60c3a19a-81a7-43d7-bb0a-f07242b1111f" = true
+[60c3a19a-81a7-43d7-bb0a-f07242b1111f]
+description = "items cleared out of buffer can't be read"
+include = true
 
-# clear frees up capacity for another write
-"45f3ae89-3470-49f3-b50e-362e4b330a59" = true
+[45f3ae89-3470-49f3-b50e-362e4b330a59]
+description = "clear frees up capacity for another write"
+include = true
 
-# clear does nothing on empty buffer
-"e1ac5170-a026-4725-bfbe-0cf332eddecd" = true
+[e1ac5170-a026-4725-bfbe-0cf332eddecd]
+description = "clear does nothing on empty buffer"
+include = true
 
-# overwrite acts like write on non-full buffer
-"9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b" = true
+[9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b]
+description = "overwrite acts like write on non-full buffer"
+include = true
 
-# overwrite replaces the oldest item on full buffer
-"880f916b-5039-475c-bd5c-83463c36a147" = true
+[880f916b-5039-475c-bd5c-83463c36a147]
+description = "overwrite replaces the oldest item on full buffer"
+include = true
 
-# overwrite replaces the oldest item remaining in buffer following a read
-"bfecab5b-aca1-4fab-a2b0-cd4af2b053c3" = true
+[bfecab5b-aca1-4fab-a2b0-cd4af2b053c3]
+description = "overwrite replaces the oldest item remaining in buffer following a read"
+include = true
 
-# initial clear does not affect wrapping around
-"9cebe63a-c405-437b-8b62-e3fdc1ecec5a" = true
+[9cebe63a-c405-437b-8b62-e3fdc1ecec5a]
+description = "initial clear does not affect wrapping around"
+include = true

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -1,157 +1,211 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# on the hour
-"a577bacc-106b-496e-9792-b3083ea8705e" = true
+[a577bacc-106b-496e-9792-b3083ea8705e]
+description = "on the hour"
+include = true
 
-# past the hour
-"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = true
+[b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
+description = "past the hour"
+include = true
 
-# midnight is zero hours
-"473223f4-65f3-46ff-a9f7-7663c7e59440" = true
+[473223f4-65f3-46ff-a9f7-7663c7e59440]
+description = "midnight is zero hours"
+include = true
 
-# hour rolls over
-"ca95d24a-5924-447d-9a96-b91c8334725c" = true
+[ca95d24a-5924-447d-9a96-b91c8334725c]
+description = "hour rolls over"
+include = true
 
-# hour rolls over continuously
-"f3826de0-0925-4d69-8ac8-89aea7e52b78" = true
+[f3826de0-0925-4d69-8ac8-89aea7e52b78]
+description = "hour rolls over continuously"
+include = true
 
-# sixty minutes is next hour
-"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = true
+[a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
+description = "sixty minutes is next hour"
+include = true
 
-# minutes roll over
-"8f520df6-b816-444d-b90f-8a477789beb5" = true
+[8f520df6-b816-444d-b90f-8a477789beb5]
+description = "minutes roll over"
+include = true
 
-# minutes roll over continuously
-"c75c091b-47ac-4655-8d40-643767fc4eed" = true
+[c75c091b-47ac-4655-8d40-643767fc4eed]
+description = "minutes roll over continuously"
+include = true
 
-# hour and minutes roll over
-"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = true
+[06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
+description = "hour and minutes roll over"
+include = true
 
-# hour and minutes roll over continuously
-"be60810e-f5d9-4b58-9351-a9d1e90e660c" = true
+[be60810e-f5d9-4b58-9351-a9d1e90e660c]
+description = "hour and minutes roll over continuously"
+include = true
 
-# hour and minutes roll over to exactly midnight
-"1689107b-0b5c-4bea-aad3-65ec9859368a" = true
+[1689107b-0b5c-4bea-aad3-65ec9859368a]
+description = "hour and minutes roll over to exactly midnight"
+include = true
 
-# negative hour
-"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = true
+[d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
+description = "negative hour"
+include = true
 
-# negative hour rolls over
-"77ef6921-f120-4d29-bade-80d54aa43b54" = true
+[77ef6921-f120-4d29-bade-80d54aa43b54]
+description = "negative hour rolls over"
+include = true
 
-# negative hour rolls over continuously
-"359294b5-972f-4546-bb9a-a85559065234" = true
+[359294b5-972f-4546-bb9a-a85559065234]
+description = "negative hour rolls over continuously"
+include = true
 
-# negative minutes
-"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = true
+[509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
+description = "negative minutes"
+include = true
 
-# negative minutes roll over
-"5d6bb225-130f-4084-84fd-9e0df8996f2a" = true
+[5d6bb225-130f-4084-84fd-9e0df8996f2a]
+description = "negative minutes roll over"
+include = true
 
-# negative minutes roll over continuously
-"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = true
+[d483ceef-b520-4f0c-b94a-8d2d58cf0484]
+description = "negative minutes roll over continuously"
+include = true
 
-# negative sixty minutes is previous hour
-"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = true
+[1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
+description = "negative sixty minutes is previous hour"
+include = true
 
-# negative hour and minutes both roll over
-"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = true
+[9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
+description = "negative hour and minutes both roll over"
+include = true
 
-# negative hour and minutes both roll over continuously
-"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = true
+[51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
+description = "negative hour and minutes both roll over continuously"
+include = true
 
-# add minutes
-"d098e723-ad29-4ef9-997a-2693c4c9d89a" = true
+[d098e723-ad29-4ef9-997a-2693c4c9d89a]
+description = "add minutes"
+include = true
 
-# add no minutes
-"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = true
+[b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
+description = "add no minutes"
+include = true
 
-# add to next hour
-"efd349dd-0785-453e-9ff8-d7452a8e7269" = true
+[efd349dd-0785-453e-9ff8-d7452a8e7269]
+description = "add to next hour"
+include = true
 
-# add more than one hour
-"749890f7-aba9-4702-acce-87becf4ef9fe" = true
+[749890f7-aba9-4702-acce-87becf4ef9fe]
+description = "add more than one hour"
+include = true
 
-# add more than two hours with carry
-"da63e4c1-1584-46e3-8d18-c9dc802c1713" = true
+[da63e4c1-1584-46e3-8d18-c9dc802c1713]
+description = "add more than two hours with carry"
+include = true
 
-# add across midnight
-"be167a32-3d33-4cec-a8bc-accd47ddbb71" = true
+[be167a32-3d33-4cec-a8bc-accd47ddbb71]
+description = "add across midnight"
+include = true
 
-# add more than one day (1500 min = 25 hrs)
-"6672541e-cdae-46e4-8be7-a820cc3be2a8" = true
+[6672541e-cdae-46e4-8be7-a820cc3be2a8]
+description = "add more than one day (1500 min = 25 hrs)"
+include = true
 
-# add more than two days
-"1918050d-c79b-4cb7-b707-b607e2745c7e" = true
+[1918050d-c79b-4cb7-b707-b607e2745c7e]
+description = "add more than two days"
+include = true
 
-# subtract minutes
-"37336cac-5ede-43a5-9026-d426cbe40354" = true
+[37336cac-5ede-43a5-9026-d426cbe40354]
+description = "subtract minutes"
+include = true
 
-# subtract to previous hour
-"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = true
+[0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
+description = "subtract to previous hour"
+include = true
 
-# subtract more than an hour
-"9b4e809c-612f-4b15-aae0-1df0acb801b9" = true
+[9b4e809c-612f-4b15-aae0-1df0acb801b9]
+description = "subtract more than an hour"
+include = true
 
-# subtract across midnight
-"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = true
+[8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
+description = "subtract across midnight"
+include = true
 
-# subtract more than two hours
-"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = true
+[07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
+description = "subtract more than two hours"
+include = true
 
-# subtract more than two hours with borrow
-"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = true
+[90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
+description = "subtract more than two hours with borrow"
+include = true
 
-# subtract more than one day (1500 min = 25 hrs)
-"2149f985-7136-44ad-9b29-ec023a97a2b7" = true
+[2149f985-7136-44ad-9b29-ec023a97a2b7]
+description = "subtract more than one day (1500 min = 25 hrs)"
+include = true
 
-# subtract more than two days
-"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = true
+[ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
+description = "subtract more than two days"
+include = true
 
-# clocks with same time
-"f2fdad51-499f-4c9b-a791-b28c9282e311" = true
+[f2fdad51-499f-4c9b-a791-b28c9282e311]
+description = "clocks with same time"
+include = true
 
-# clocks a minute apart
-"5d409d4b-f862-4960-901e-ec430160b768" = true
+[5d409d4b-f862-4960-901e-ec430160b768]
+description = "clocks a minute apart"
+include = true
 
-# clocks an hour apart
-"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = true
+[a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
+description = "clocks an hour apart"
+include = true
 
-# clocks with hour overflow
-"66b12758-0be5-448b-a13c-6a44bce83527" = true
+[66b12758-0be5-448b-a13c-6a44bce83527]
+description = "clocks with hour overflow"
+include = true
 
-# clocks with hour overflow by several days
-"2b19960c-212e-4a71-9aac-c581592f8111" = true
+[2b19960c-212e-4a71-9aac-c581592f8111]
+description = "clocks with hour overflow by several days"
+include = true
 
-# clocks with negative hour
-"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = true
+[6f8c6541-afac-4a92-b0c2-b10d4e50269f]
+description = "clocks with negative hour"
+include = true
 
-# clocks with negative hour that wraps
-"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = true
+[bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
+description = "clocks with negative hour that wraps"
+include = true
 
-# clocks with negative hour that wraps multiple times
-"56c0326d-565b-4d19-a26f-63b3205778b7" = true
+[56c0326d-565b-4d19-a26f-63b3205778b7]
+description = "clocks with negative hour that wraps multiple times"
+include = true
 
-# clocks with minute overflow
-"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = true
+[c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
+description = "clocks with minute overflow"
+include = true
 
-# clocks with minute overflow by several days
-"533a3dc5-59a7-491b-b728-a7a34fe325de" = true
+[533a3dc5-59a7-491b-b728-a7a34fe325de]
+description = "clocks with minute overflow by several days"
+include = true
 
-# clocks with negative minute
-"fff49e15-f7b7-4692-a204-0f6052d62636" = true
+[fff49e15-f7b7-4692-a204-0f6052d62636]
+description = "clocks with negative minute"
+include = true
 
-# clocks with negative minute that wraps
-"605c65bb-21bd-43eb-8f04-878edf508366" = true
+[605c65bb-21bd-43eb-8f04-878edf508366]
+description = "clocks with negative minute that wraps"
+include = true
 
-# clocks with negative minute that wraps multiple times
-"b87e64ed-212a-4335-91fd-56da8421d077" = true
+[b87e64ed-212a-4335-91fd-56da8421d077]
+description = "clocks with negative minute that wraps multiple times"
+include = true
 
-# clocks with negative hours and minutes
-"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = true
+[822fbf26-1f3b-4b13-b9bf-c914816b53dd]
+description = "clocks with negative hours and minutes"
+include = true
 
-# clocks with negative hours and minutes that wrap
-"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = true
+[e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
+description = "clocks with negative hours and minutes that wrap"
+include = true
 
-# full clock and zeroed clock
-"96969ca8-875a-48a1-86ae-257a528c44f5" = true
+[96969ca8-875a-48a1-86ae-257a528c44f5]
+description = "full clock and zeroed clock"
+include = true

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero steps for one
-"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = true
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+include = true
 
-# divide if even
-"3d76a0a6-ea84-444a-821a-f7857c2c1859" = true
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+include = true
 
-# even and odd steps
-"754dea81-123c-429e-b8bc-db20b05a87b9" = true
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+include = true
 
-# large number of even and odd steps
-"ecfd0210-6f85-44f6-8280-f65534892ff6" = true
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+include = true
 
-# zero is an error
-"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = true
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = true
 
-# negative value is an error
-"c6c795bf-a288-45e9-86a1-841359ad426d" = true
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = true

--- a/exercises/practice/complex-numbers/.meta/tests.toml
+++ b/exercises/practice/complex-numbers/.meta/tests.toml
@@ -1,94 +1,127 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Real part of a purely real number
-"9f98e133-eb7f-45b0-9676-cce001cd6f7a" = true
+[9f98e133-eb7f-45b0-9676-cce001cd6f7a]
+description = "Real part of a purely real number"
+include = true
 
-# Real part of a purely imaginary number
-"07988e20-f287-4bb7-90cf-b32c4bffe0f3" = true
+[07988e20-f287-4bb7-90cf-b32c4bffe0f3]
+description = "Real part of a purely imaginary number"
+include = true
 
-# Real part of a number with real and imaginary part
-"4a370e86-939e-43de-a895-a00ca32da60a" = true
+[4a370e86-939e-43de-a895-a00ca32da60a]
+description = "Real part of a number with real and imaginary part"
+include = true
 
-# Imaginary part of a purely real number
-"9b3fddef-4c12-4a99-b8f8-e3a42c7ccef6" = true
+[9b3fddef-4c12-4a99-b8f8-e3a42c7ccef6]
+description = "Imaginary part of a purely real number"
+include = true
 
-# Imaginary part of a purely imaginary number
-"a8dafedd-535a-4ed3-8a39-fda103a2b01e" = true
+[a8dafedd-535a-4ed3-8a39-fda103a2b01e]
+description = "Imaginary part of a purely imaginary number"
+include = true
 
-# Imaginary part of a number with real and imaginary part
-"0f998f19-69ee-4c64-80ef-01b086feab80" = true
+[0f998f19-69ee-4c64-80ef-01b086feab80]
+description = "Imaginary part of a number with real and imaginary part"
+include = true
 
-# Imaginary unit
-"a39b7fd6-6527-492f-8c34-609d2c913879" = true
+[a39b7fd6-6527-492f-8c34-609d2c913879]
+description = "Imaginary unit"
+include = true
 
-# Add purely real numbers
-"9a2c8de9-f068-4f6f-b41c-82232cc6c33e" = true
+[9a2c8de9-f068-4f6f-b41c-82232cc6c33e]
+description = "Add purely real numbers"
+include = true
 
-# Add purely imaginary numbers
-"657c55e1-b14b-4ba7-bd5c-19db22b7d659" = true
+[657c55e1-b14b-4ba7-bd5c-19db22b7d659]
+description = "Add purely imaginary numbers"
+include = true
 
-# Add numbers with real and imaginary part
-"4e1395f5-572b-4ce8-bfa9-9a63056888da" = true
+[4e1395f5-572b-4ce8-bfa9-9a63056888da]
+description = "Add numbers with real and imaginary part"
+include = true
 
-# Subtract purely real numbers
-"1155dc45-e4f7-44b8-af34-a91aa431475d" = true
+[1155dc45-e4f7-44b8-af34-a91aa431475d]
+description = "Subtract purely real numbers"
+include = true
 
-# Subtract purely imaginary numbers
-"f95e9da8-acd5-4da4-ac7c-c861b02f774b" = true
+[f95e9da8-acd5-4da4-ac7c-c861b02f774b]
+description = "Subtract purely imaginary numbers"
+include = true
 
-# Subtract numbers with real and imaginary part
-"f876feb1-f9d1-4d34-b067-b599a8746400" = true
+[f876feb1-f9d1-4d34-b067-b599a8746400]
+description = "Subtract numbers with real and imaginary part"
+include = true
 
-# Multiply purely real numbers
-"8a0366c0-9e16-431f-9fd7-40ac46ff4ec4" = true
+[8a0366c0-9e16-431f-9fd7-40ac46ff4ec4]
+description = "Multiply purely real numbers"
+include = true
 
-# Multiply purely imaginary numbers
-"e560ed2b-0b80-4b4f-90f2-63cefc911aaf" = true
+[e560ed2b-0b80-4b4f-90f2-63cefc911aaf]
+description = "Multiply purely imaginary numbers"
+include = true
 
-# Multiply numbers with real and imaginary part
-"4d1d10f0-f8d4-48a0-b1d0-f284ada567e6" = true
+[4d1d10f0-f8d4-48a0-b1d0-f284ada567e6]
+description = "Multiply numbers with real and imaginary part"
+include = true
 
-# Divide purely real numbers
-"b0571ddb-9045-412b-9c15-cd1d816d36c1" = true
+[b0571ddb-9045-412b-9c15-cd1d816d36c1]
+description = "Divide purely real numbers"
+include = true
 
-# Divide purely imaginary numbers
-"5bb4c7e4-9934-4237-93cc-5780764fdbdd" = true
+[5bb4c7e4-9934-4237-93cc-5780764fdbdd]
+description = "Divide purely imaginary numbers"
+include = true
 
-# Divide numbers with real and imaginary part
-"c4e7fef5-64ac-4537-91c2-c6529707701f" = true
+[c4e7fef5-64ac-4537-91c2-c6529707701f]
+description = "Divide numbers with real and imaginary part"
+include = true
 
-# Absolute value of a positive purely real number
-"c56a7332-aad2-4437-83a0-b3580ecee843" = true
+[c56a7332-aad2-4437-83a0-b3580ecee843]
+description = "Absolute value of a positive purely real number"
+include = true
 
-# Absolute value of a negative purely real number
-"cf88d7d3-ee74-4f4e-8a88-a1b0090ecb0c" = true
+[cf88d7d3-ee74-4f4e-8a88-a1b0090ecb0c]
+description = "Absolute value of a negative purely real number"
+include = true
 
-# Absolute value of a purely imaginary number with positive imaginary part
-"bbe26568-86c1-4bb4-ba7a-da5697e2b994" = true
+[bbe26568-86c1-4bb4-ba7a-da5697e2b994]
+description = "Absolute value of a purely imaginary number with positive imaginary part"
+include = true
 
-# Absolute value of a purely imaginary number with negative imaginary part
-"3b48233d-468e-4276-9f59-70f4ca1f26f3" = true
+[3b48233d-468e-4276-9f59-70f4ca1f26f3]
+description = "Absolute value of a purely imaginary number with negative imaginary part"
+include = true
 
-# Absolute value of a number with real and imaginary part
-"fe400a9f-aa22-4b49-af92-51e0f5a2a6d3" = true
+[fe400a9f-aa22-4b49-af92-51e0f5a2a6d3]
+description = "Absolute value of a number with real and imaginary part"
+include = true
 
-# Conjugate a purely real number
-"fb2d0792-e55a-4484-9443-df1eddfc84a2" = true
+[fb2d0792-e55a-4484-9443-df1eddfc84a2]
+description = "Conjugate a purely real number"
+include = true
 
-# Conjugate a purely imaginary number
-"e37fe7ac-a968-4694-a460-66cb605f8691" = true
+[e37fe7ac-a968-4694-a460-66cb605f8691]
+description = "Conjugate a purely imaginary number"
+include = true
 
-# Conjugate a number with real and imaginary part
-"f7704498-d0be-4192-aaf5-a1f3a7f43e68" = true
+[f7704498-d0be-4192-aaf5-a1f3a7f43e68]
+description = "Conjugate a number with real and imaginary part"
+include = true
 
-# Euler's identity/formula
-"6d96d4c6-2edb-445b-94a2-7de6d4caaf60" = true
+[6d96d4c6-2edb-445b-94a2-7de6d4caaf60]
+description = "Euler's identity/formula"
+include = true
 
-# Exponential of 0
-"2d2c05a0-4038-4427-a24d-72f6624aa45f" = true
+[2d2c05a0-4038-4427-a24d-72f6624aa45f]
+description = "Exponential of 0"
+include = true
 
-# Exponential of a purely real number
-"ed87f1bd-b187-45d6-8ece-7e331232c809" = true
+[ed87f1bd-b187-45d6-8ece-7e331232c809]
+description = "Exponential of a purely real number"
+include = true
 
-# Exponential of a number with real and imaginary part
-"08eedacc-5a95-44fc-8789-1547b27a8702" = true
+[08eedacc-5a95-44fc-8789-1547b27a8702]
+description = "Exponential of a number with real and imaginary part"
+include = true

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,22 +1,31 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty plaintext results in an empty ciphertext
-"407c3837-9aa7-4111-ab63-ec54b58e8e9f" = true
+[407c3837-9aa7-4111-ab63-ec54b58e8e9f]
+description = "empty plaintext results in an empty ciphertext"
+include = true
 
-# Lowercase
-"64131d65-6fd9-4f58-bdd8-4a2370fb481d" = true
+[64131d65-6fd9-4f58-bdd8-4a2370fb481d]
+description = "Lowercase"
+include = true
 
-# Remove spaces
-"63a4b0ed-1e3c-41ea-a999-f6f26ba447d6" = true
+[63a4b0ed-1e3c-41ea-a999-f6f26ba447d6]
+description = "Remove spaces"
+include = true
 
-# Remove punctuation
-"1b5348a1-7893-44c1-8197-42d48d18756c" = true
+[1b5348a1-7893-44c1-8197-42d48d18756c]
+description = "Remove punctuation"
+include = true
 
-# 9 character plaintext results in 3 chunks of 3 characters
-"8574a1d3-4a08-4cec-a7c7-de93a164f41a" = true
+[8574a1d3-4a08-4cec-a7c7-de93a164f41a]
+description = "9 character plaintext results in 3 chunks of 3 characters"
+include = true
 
-# 8 character plaintext results in 3 chunks, the last one with a trailing space
-"a65d3fa1-9e09-43f9-bcec-7a672aec3eae" = true
+[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]
+description = "8 character plaintext results in 3 chunks, the last one with a trailing space"
+include = true
 
-# 54 character plaintext results in 7 chunks, the last two with trailing spaces
-"fbcb0c6d-4c39-4a31-83f6-c473baa6af80" = true
+[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
+description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
+include = true

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "square of sum 1"
+include = true
 
-# square of sum 5
-"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "square of sum 5"
+include = true
 
-# square of sum 100
-"54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "square of sum 100"
+include = true
 
-# sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = true
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "sum of squares 1"
+include = true
 
-# sum of squares 5
-"c93900cd-8cc2-4ca4-917b-dd3027023499" = true
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "sum of squares 5"
+include = true
 
-# sum of squares 100
-"94807386-73e4-4d9e-8dec-69eb135b19e4" = true
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "sum of squares 100"
+include = true
 
-# difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "difference of squares 1"
+include = true
 
-# difference of squares 5
-"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "difference of squares 5"
+include = true
 
-# difference of squares 100
-"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = true
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "difference of squares 100"
+include = true

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,13 +1,19 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single letter
-"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+include = true
 
-# single score with multiple letters
-"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+include = true
 
-# multiple scores with multiple letters
-"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+include = true
 
-# multiple scores with differing numbers of letters
-"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"
+include = true

--- a/exercises/practice/food-chain/.meta/tests.toml
+++ b/exercises/practice/food-chain/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# fly
-"751dce68-9412-496e-b6e8-855998c56166" = true
+[751dce68-9412-496e-b6e8-855998c56166]
+description = "fly"
+include = true
 
-# spider
-"6c56f861-0c5e-4907-9a9d-b2efae389379" = true
+[6c56f861-0c5e-4907-9a9d-b2efae389379]
+description = "spider"
+include = true
 
-# bird
-"3edf5f33-bef1-4e39-ae67-ca5eb79203fa" = true
+[3edf5f33-bef1-4e39-ae67-ca5eb79203fa]
+description = "bird"
+include = true
 
-# cat
-"e866a758-e1ff-400e-9f35-f27f28cc288f" = true
+[e866a758-e1ff-400e-9f35-f27f28cc288f]
+description = "cat"
+include = true
 
-# dog
-"3f02c30e-496b-4b2a-8491-bc7e2953cafb" = true
+[3f02c30e-496b-4b2a-8491-bc7e2953cafb]
+description = "dog"
+include = true
 
-# goat
-"4b3fd221-01ea-46e0-825b-5734634fbc59" = true
+[4b3fd221-01ea-46e0-825b-5734634fbc59]
+description = "goat"
+include = true
 
-# cow
-"1b707da9-7001-4fac-941f-22ad9c7a65d4" = true
+[1b707da9-7001-4fac-941f-22ad9c7a65d4]
+description = "cow"
+include = true
 
-# horse
-"3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc" = true
+[3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc]
+description = "horse"
+include = true
 
-# multiple verses
-"22b863d5-17e4-4d1e-93e4-617329a5c050" = true
+[22b863d5-17e4-4d1e-93e4-617329a5c050]
+description = "multiple verses"
+include = true
 
-# full song
-"e626b32b-745c-4101-bcbd-3b13456893db" = true
+[e626b32b-745c-4101-bcbd-3b13456893db]
+description = "full song"
+include = true

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# date only specification of time
-"92fbe71c-ea52-4fac-bd77-be38023cacf7" = true
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+include = true
 
-# second test for date only specification of time
-"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = true
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+include = true
 
-# third test for date only specification of time
-"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = true
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+include = true
 
-# full time specified
-"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = true
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+include = true
 
-# full time with day roll-over
-"09d4e30e-728a-4b52-9005-be44a58d9eba" = true
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"
+include = true

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,22 +1,31 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Adding a student adds them to the sorted roster
-"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Adding a student adds them to the sorted roster"
+include = true
 
-# Adding more student adds them to the sorted roster
-"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Adding more student adds them to the sorted roster"
+include = true
 
-# Adding students to different grades adds them to the same sorted roster
-"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Adding students to different grades adds them to the same sorted roster"
+include = true
 
-# Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+[a3f0fb58-f240-4723-8ddc-e644666b85cc]
+description = "Roster returns an empty list if there are no students enrolled"
+include = true
 
-# Student names with grades are displayed in the same sorted roster
-"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
+description = "Student names with grades are displayed in the same sorted roster"
+include = true
 
-# Grade returns the students in that grade in alphabetical order
-"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Grade returns the students in that grade in alphabetical order"
+include = true
 
-# Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true
+[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
+description = "Grade returns an empty list if there are no students in that grade"
+include = true

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1
-"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true
+[9fbde8de-36b2-49de-baf2-cd42d6f28405]
+description = "1"
+include = true
 
-# 2
-"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true
+[ee1f30c2-01d8-4298-b25d-c677331b5e6d]
+description = "2"
+include = true
 
-# 3
-"10f45584-2fc3-4875-8ec6-666065d1163b" = true
+[10f45584-2fc3-4875-8ec6-666065d1163b]
+description = "3"
+include = true
 
-# 4
-"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true
+[a7cbe01b-36f4-4601-b053-c5f6ae055170]
+description = "4"
+include = true
 
-# 16
-"c50acc89-8535-44e4-918f-b848ad2817d4" = true
+[c50acc89-8535-44e4-918f-b848ad2817d4]
+description = "16"
+include = true
 
-# 32
-"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true
+[acd81b46-c2ad-4951-b848-80d15ed5a04f]
+description = "32"
+include = true
 
-# 64
-"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "64"
+include = true
 
-# square 0 raises an exception
-"1d47d832-3e85-4974-9466-5bd35af484e3" = true
+[1d47d832-3e85-4974-9466-5bd35af484e3]
+description = "square 0 raises an exception"
+include = true
 
-# negative square raises an exception
-"61974483-eeb2-465e-be54-ca5dde366453" = true
+[61974483-eeb2-465e-be54-ca5dde366453]
+description = "negative square raises an exception"
+include = true
 
-# square greater than 64 raises an exception
-"a95e4374-f32c-45a7-a10d-ffec475c012f" = true
+[a95e4374-f32c-45a7-a10d-ffec475c012f]
+description = "square greater than 64 raises an exception"
+include = true
 
-# returns the total number of grains on the board
-"6eb07385-3659-4b45-a6be-9dc474222750" = true
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"
+include = true

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+include = true
 
-# single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = true
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+include = true
 
-# single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+include = true
 
-# long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+include = true
 
-# long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+include = true
 
-# disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+include = true
 
-# disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+include = true
 
-# disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+include = true
 
-# disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+include = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,4 +1,7 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"
+include = true

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,40 +1,55 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty string
-"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+include = true
 
-# isogram with only lower case characters
-"9a001b50-f194-4143-bc29-2af5ec1ef652" = true
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+include = true
 
-# word with one duplicated character
-"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = true
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+include = true
 
-# word with one duplicated character from the end of the alphabet
-"6450b333-cbc2-4b24-a723-0b459b34fe18" = true
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+include = true
 
-# longest reported english isogram
-"a15ff557-dd04-4764-99e7-02cc1a385863" = true
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+include = true
 
-# word with duplicated character in mixed case
-"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = true
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+include = true
 
-# word with duplicated character in mixed case, lowercase first
-"14a4f3c1-3b47-4695-b645-53d328298942" = true
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+include = true
 
-# hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+include = true
 
-# hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+include = true
 
-# isogram with duplicated hyphen
-"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+include = true
 
-# made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+include = true
 
-# duplicated character in the middle
-"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+include = true
 
-# same first and last characters
-"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = true
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+include = true

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = true
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+include = true
 
-# year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+include = true
 
-# year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+include = true
 
-# year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+include = true
 
-# year divisible by 100, not divisible by 400 in common year
-"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+include = true
 
-# year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+include = true
 
-# year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 in leap year"
+include = true
 
-# year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = true
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+include = true
 
-# year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"
+include = true

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single digit strings can not be valid
-"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+[792a7082-feb7-48c7-b88b-bbfec160865e]
+description = "single digit strings can not be valid"
+include = true
 
-# a single zero is invalid
-"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+[698a7924-64d4-4d89-8daa-32e1aadc271e]
+description = "a single zero is invalid"
+include = true
 
-# a simple valid SIN that remains valid if reversed
-"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+[73c2f62b-9b10-4c9f-9a04-83cee7367965]
+description = "a simple valid SIN that remains valid if reversed"
+include = true
 
-# a simple valid SIN that becomes invalid if reversed
-"9369092e-b095-439f-948d-498bd076be11" = true
+[9369092e-b095-439f-948d-498bd076be11]
+description = "a simple valid SIN that becomes invalid if reversed"
+include = true
 
-# a valid Canadian SIN
-"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+[8f9f2350-1faf-4008-ba84-85cbb93ffeca]
+description = "a valid Canadian SIN"
+include = true
 
-# invalid Canadian SIN
-"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+[1cdcf269-6560-44fc-91f6-5819a7548737]
+description = "invalid Canadian SIN"
+include = true
 
-# invalid credit card
-"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+[656c48c1-34e8-4e60-9a5a-aad8a367810a]
+description = "invalid credit card"
+include = true
 
-# invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+[20e67fad-2121-43ed-99a8-14b5b856adb9]
+description = "invalid long number with an even remainder"
+include = true
 
-# valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+[ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
+description = "valid number with an even number of digits"
+include = true
 
-# valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = true
+[ef081c06-a41f-4761-8492-385e13c8202d]
+description = "valid number with an odd number of spaces"
+include = true
 
-# valid strings with a non-digit added at the end become invalid
-"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+[bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
+description = "valid strings with a non-digit added at the end become invalid"
+include = true
 
-# valid strings with punctuation included become invalid
-"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+[2177e225-9ce7-40f6-b55d-fa420e62938e]
+description = "valid strings with punctuation included become invalid"
+include = true
 
-# valid strings with symbols included become invalid
-"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+[ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
+description = "valid strings with symbols included become invalid"
+include = true
 
-# single zero with space is invalid
-"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+[08195c5e-ce7f-422c-a5eb-3e45fece68ba]
+description = "single zero with space is invalid"
+include = true
 
-# more than a single zero is valid
-"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+[12e63a3c-f866-4a79-8c14-b359fc386091]
+description = "more than a single zero is valid"
+include = true
 
-# input digit 9 is correctly converted to output digit 9
-"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+[ab56fa80-5de8-4735-8a4a-14dae588663e]
+description = "input digit 9 is correctly converted to output digit 9"
+include = true
 
-# using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+[39a06a5a-5bad-4e0f-b215-b042d46209b1]
+description = "using ascii value for non-doubled non-digit isn't allowed"
+include = true
 
-# using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = true
+[f94cf191-a62f-4868-bc72-7253114aa157]
+description = "using ascii value for doubled non-digit isn't allowed"
+include = true

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,52 +1,71 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# paired square brackets
-"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
+include = true
 
-# empty string
-"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
+include = true
 
-# unpaired brackets
-"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
+include = true
 
-# wrong ordered brackets
-"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
+include = true
 
-# wrong closing bracket
-"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
+include = true
 
-# paired with whitespace
-"754468e0-4696-4582-a30e-534d47d69756" = true
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
+include = true
 
-# partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
+include = true
 
-# simple nested brackets
-"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
+include = true
 
-# several paired brackets
-"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
+include = true
 
-# paired and nested brackets
-"2e1f7b56-c137-4c92-9781-958638885a44" = true
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
+include = true
 
-# unopened closing brackets
-"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
+include = true
 
-# unpaired and nested brackets
-"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
+include = true
 
-# paired and wrong nested brackets
-"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
+include = true
 
-# paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
+include = true
 
-# too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
+include = true
 
-# math expression
-"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
+include = true
 
-# complex latex expression
-"8e357d79-f302-469a-8515-2561877256a1" = true
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"
+include = true

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -1,286 +1,383 @@
-[canonical-tests]
-
-# monteenth of May 2013
-"d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8" = true
-
-# monteenth of August 2013
-"f78373d1-cd53-4a7f-9d37-e15bf8a456b4" = true
-
-# monteenth of September 2013
-"8c78bea7-a116-425b-9c6b-c9898266d92a" = true
-
-# tuesteenth of March 2013
-"cfef881b-9dc9-4d0b-8de4-82d0f39fc271" = true
-
-# tuesteenth of April 2013
-"69048961-3b00-41f9-97ee-eb6d83a8e92b" = true
-
-# tuesteenth of August 2013
-"d30bade8-3622-466a-b7be-587414e0caa6" = true
-
-# wednesteenth of January 2013
-"8db4b58b-92f3-4687-867b-82ee1a04f851" = true
-
-# wednesteenth of February 2013
-"6c27a2a2-28f8-487f-ae81-35d08c4664f7" = true
-
-# wednesteenth of June 2013
-"008a8674-1958-45b5-b8e6-c2c9960d973a" = true
-
-# thursteenth of May 2013
-"e4abd5e3-57cb-4091-8420-d97e955c0dbd" = true
-
-# thursteenth of June 2013
-"85da0b0f-eace-4297-a6dd-63588d5055b4" = true
-
-# thursteenth of September 2013
-"ecf64f9b-8413-489b-bf6e-128045f70bcc" = true
-
-# friteenth of April 2013
-"ac4e180c-7d0a-4d3d-b05f-f564ebb584ca" = true
-
-# friteenth of August 2013
-"b79101c7-83ad-4f8f-8ec8-591683296315" = true
-
-# friteenth of September 2013
-"6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8" = true
-
-# saturteenth of February 2013
-"dfae03ed-9610-47de-a632-655ab01e1e7c" = true
-
-# saturteenth of April 2013
-"ec02e3e1-fc72-4a3c-872f-a53fa8ab358e" = true
-
-# saturteenth of October 2013
-"d983094b-7259-4195-b84e-5d09578c89d9" = true
-
-# sunteenth of May 2013
-"d84a2a2e-f745-443a-9368-30051be60c2e" = true
-
-# sunteenth of June 2013
-"0e64bc53-92a3-4f61-85b2-0b7168c7ce5a" = true
-
-# sunteenth of October 2013
-"de87652c-185e-4854-b3ae-04cf6150eead" = true
-
-# first Monday of March 2013
-"2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411" = true
-
-# first Monday of April 2013
-"a6168c7c-ed95-4bb3-8f92-c72575fc64b0" = true
-
-# first Tuesday of May 2013
-"1bfc620f-1c54-4bbd-931f-4a1cd1036c20" = true
-
-# first Tuesday of June 2013
-"12959c10-7362-4ca0-a048-50cf1c06e3e2" = true
-
-# first Wednesday of July 2013
-"1033dc66-8d0b-48a1-90cb-270703d59d1d" = true
-
-# first Wednesday of August 2013
-"b89185b9-2f32-46f4-a602-de20b09058f6" = true
-
-# first Thursday of September 2013
-"53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5" = true
-
-# first Thursday of October 2013
-"b420a7e3-a94c-4226-870a-9eb3a92647f0" = true
-
-# first Friday of November 2013
-"61df3270-28b4-4713-bee2-566fa27302ca" = true
-
-# first Friday of December 2013
-"cad33d4d-595c-412f-85cf-3874c6e07abf" = true
-
-# first Saturday of January 2013
-"a2869b52-5bba-44f0-a863-07bd1f67eadb" = true
-
-# first Saturday of February 2013
-"3585315a-d0db-4ea1-822e-0f22e2a645f5" = true
-
-# first Sunday of March 2013
-"c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1" = true
-
-# first Sunday of April 2013
-"1513328b-df53-4714-8677-df68c4f9366c" = true
-
-# second Monday of March 2013
-"49e083af-47ec-4018-b807-62ef411efed7" = true
-
-# second Monday of April 2013
-"6cb79a73-38fe-4475-9101-9eec36cf79e5" = true
-
-# second Tuesday of May 2013
-"4c39b594-af7e-4445-aa03-bf4f8effd9a1" = true
-
-# second Tuesday of June 2013
-"41b32c34-2e39-40e3-b790-93539aaeb6dd" = true
-
-# second Wednesday of July 2013
-"90a160c5-b5d9-4831-927f-63a78b17843d" = true
-
-# second Wednesday of August 2013
-"23b98ce7-8dd5-41a1-9310-ef27209741cb" = true
-
-# second Thursday of September 2013
-"447f1960-27ca-4729-bc3f-f36043f43ed0" = true
-
-# second Thursday of October 2013
-"c9aa2687-300c-4e79-86ca-077849a81bde" = true
-
-# second Friday of November 2013
-"a7e11ef3-6625-4134-acda-3e7195421c09" = true
-
-# second Friday of December 2013
-"8b420e5f-9290-4106-b5ae-022f3e2a3e41" = true
-
-# second Saturday of January 2013
-"80631afc-fc11-4546-8b5f-c12aaeb72b4f" = true
-
-# second Saturday of February 2013
-"e34d43ac-f470-44c2-aa5f-e97b78ecaf83" = true
-
-# second Sunday of March 2013
-"a57d59fd-1023-47ad-b0df-a6feb21b44fc" = true
-
-# second Sunday of April 2013
-"a829a8b0-abdd-4ad1-b66c-5560d843c91a" = true
-
-# third Monday of March 2013
-"501a8a77-6038-4fc0-b74c-33634906c29d" = true
-
-# third Monday of April 2013
-"49e4516e-cf32-4a58-8bbc-494b7e851c92" = true
-
-# third Tuesday of May 2013
-"4db61095-f7c7-493c-85f1-9996ad3012c7" = true
-
-# third Tuesday of June 2013
-"714fc2e3-58d0-4b91-90fd-61eefd2892c0" = true
-
-# third Wednesday of July 2013
-"b08a051a-2c80-445b-9b0e-524171a166d1" = true
-
-# third Wednesday of August 2013
-"80bb9eff-3905-4c61-8dc9-bb03016d8ff8" = true
-
-# third Thursday of September 2013
-"fa52a299-f77f-4784-b290-ba9189fbd9c9" = true
-
-# third Thursday of October 2013
-"f74b1bc6-cc5c-4bf1-ba69-c554a969eb38" = true
-
-# third Friday of November 2013
-"8900f3b0-801a-466b-a866-f42d64667abd" = true
-
-# third Friday of December 2013
-"538ac405-a091-4314-9ccd-920c4e38e85e" = true
-
-# third Saturday of January 2013
-"244db35c-2716-4fa0-88ce-afd58e5cf910" = true
-
-# third Saturday of February 2013
-"dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e" = true
-
-# third Sunday of March 2013
-"be71dcc6-00d2-4b53-a369-cbfae55b312f" = true
-
-# third Sunday of April 2013
-"b7d2da84-4290-4ee6-a618-ee124ae78be7" = true
-
-# fourth Monday of March 2013
-"4276dc06-a1bd-4fc2-b6c2-625fee90bc88" = true
-
-# fourth Monday of April 2013
-"ddbd7976-2deb-4250-8a38-925ac1a8e9a2" = true
-
-# fourth Tuesday of May 2013
-"eb714ef4-1656-47cc-913c-844dba4ebddd" = true
-
-# fourth Tuesday of June 2013
-"16648435-7937-4d2d-b118-c3e38fd084bd" = true
-
-# fourth Wednesday of July 2013
-"de062bdc-9484-437a-a8c5-5253c6f6785a" = true
-
-# fourth Wednesday of August 2013
-"c2ce6821-169c-4832-8d37-690ef5d9514a" = true
-
-# fourth Thursday of September 2013
-"d462c631-2894-4391-a8e3-dbb98b7a7303" = true
-
-# fourth Thursday of October 2013
-"9ff1f7b6-1b72-427d-9ee9-82b5bb08b835" = true
-
-# fourth Friday of November 2013
-"83bae8ba-1c49-49bc-b632-b7c7e1d7e35f" = true
-
-# fourth Friday of December 2013
-"de752d2a-a95e-48d2-835b-93363dac3710" = true
-
-# fourth Saturday of January 2013
-"eedd90ad-d581-45db-8312-4c6dcf9cf560" = true
-
-# fourth Saturday of February 2013
-"669fedcd-912e-48c7-a0a1-228b34af91d0" = true
-
-# fourth Sunday of March 2013
-"648e3849-ea49-44a5-a8a3-9f2a43b3bf1b" = true
-
-# fourth Sunday of April 2013
-"f81321b3-99ab-4db6-9267-69c5da5a7823" = true
-
-# last Monday of March 2013
-"1af5e51f-5488-4548-aee8-11d7d4a730dc" = true
-
-# last Monday of April 2013
-"f29999f2-235e-4ec7-9dab-26f137146526" = true
-
-# last Tuesday of May 2013
-"31b097a0-508e-48ac-bf8a-f63cdcf6dc41" = true
-
-# last Tuesday of June 2013
-"8c022150-0bb5-4a1f-80f9-88b2e2abcba4" = true
-
-# last Wednesday of July 2013
-"0e762194-672a-4bdf-8a37-1e59fdacef12" = true
-
-# last Wednesday of August 2013
-"5016386a-f24e-4bd7-b439-95358f491b66" = true
-
-# last Thursday of September 2013
-"12ead1a5-cdf9-4192-9a56-2229e93dd149" = true
-
-# last Thursday of October 2013
-"7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7" = true
-
-# last Friday of November 2013
-"e47a739e-b979-460d-9c8a-75c35ca2290b" = true
-
-# last Friday of December 2013
-"5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec" = true
-
-# last Saturday of January 2013
-"61e54cba-76f3-4772-a2b1-bf443fda2137" = true
-
-# last Saturday of February 2013
-"8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f" = true
-
-# last Sunday of March 2013
-"0b63e682-f429-4d19-9809-4a45bd0242dc" = true
-
-# last Sunday of April 2013
-"5232307e-d3e3-4afc-8ba6-4084ad987c00" = true
-
-# last Wednesday of February 2012
-"0bbd48e8-9773-4e81-8e71-b9a51711e3c5" = true
-
-# last Wednesday of December 2014
-"fe0936de-7eee-4a48-88dd-66c07ab1fefc" = true
-
-# last Sunday of February 2015
-"2ccf2488-aafc-4671-a24e-2b6effe1b0e2" = true
-
-# first Friday of December 2012
-"00c3ce9f-cf36-4b70-90d8-92b32be6830e" = true
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
+description = "monteenth of May 2013"
+include = true
+
+[f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
+description = "monteenth of August 2013"
+include = true
+
+[8c78bea7-a116-425b-9c6b-c9898266d92a]
+description = "monteenth of September 2013"
+include = true
+
+[cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
+description = "tuesteenth of March 2013"
+include = true
+
+[69048961-3b00-41f9-97ee-eb6d83a8e92b]
+description = "tuesteenth of April 2013"
+include = true
+
+[d30bade8-3622-466a-b7be-587414e0caa6]
+description = "tuesteenth of August 2013"
+include = true
+
+[8db4b58b-92f3-4687-867b-82ee1a04f851]
+description = "wednesteenth of January 2013"
+include = true
+
+[6c27a2a2-28f8-487f-ae81-35d08c4664f7]
+description = "wednesteenth of February 2013"
+include = true
+
+[008a8674-1958-45b5-b8e6-c2c9960d973a]
+description = "wednesteenth of June 2013"
+include = true
+
+[e4abd5e3-57cb-4091-8420-d97e955c0dbd]
+description = "thursteenth of May 2013"
+include = true
+
+[85da0b0f-eace-4297-a6dd-63588d5055b4]
+description = "thursteenth of June 2013"
+include = true
+
+[ecf64f9b-8413-489b-bf6e-128045f70bcc]
+description = "thursteenth of September 2013"
+include = true
+
+[ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
+description = "friteenth of April 2013"
+include = true
+
+[b79101c7-83ad-4f8f-8ec8-591683296315]
+description = "friteenth of August 2013"
+include = true
+
+[6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
+description = "friteenth of September 2013"
+include = true
+
+[dfae03ed-9610-47de-a632-655ab01e1e7c]
+description = "saturteenth of February 2013"
+include = true
+
+[ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
+description = "saturteenth of April 2013"
+include = true
+
+[d983094b-7259-4195-b84e-5d09578c89d9]
+description = "saturteenth of October 2013"
+include = true
+
+[d84a2a2e-f745-443a-9368-30051be60c2e]
+description = "sunteenth of May 2013"
+include = true
+
+[0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
+description = "sunteenth of June 2013"
+include = true
+
+[de87652c-185e-4854-b3ae-04cf6150eead]
+description = "sunteenth of October 2013"
+include = true
+
+[2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
+description = "first Monday of March 2013"
+include = true
+
+[a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
+description = "first Monday of April 2013"
+include = true
+
+[1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
+description = "first Tuesday of May 2013"
+include = true
+
+[12959c10-7362-4ca0-a048-50cf1c06e3e2]
+description = "first Tuesday of June 2013"
+include = true
+
+[1033dc66-8d0b-48a1-90cb-270703d59d1d]
+description = "first Wednesday of July 2013"
+include = true
+
+[b89185b9-2f32-46f4-a602-de20b09058f6]
+description = "first Wednesday of August 2013"
+include = true
+
+[53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
+description = "first Thursday of September 2013"
+include = true
+
+[b420a7e3-a94c-4226-870a-9eb3a92647f0]
+description = "first Thursday of October 2013"
+include = true
+
+[61df3270-28b4-4713-bee2-566fa27302ca]
+description = "first Friday of November 2013"
+include = true
+
+[cad33d4d-595c-412f-85cf-3874c6e07abf]
+description = "first Friday of December 2013"
+include = true
+
+[a2869b52-5bba-44f0-a863-07bd1f67eadb]
+description = "first Saturday of January 2013"
+include = true
+
+[3585315a-d0db-4ea1-822e-0f22e2a645f5]
+description = "first Saturday of February 2013"
+include = true
+
+[c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
+description = "first Sunday of March 2013"
+include = true
+
+[1513328b-df53-4714-8677-df68c4f9366c]
+description = "first Sunday of April 2013"
+include = true
+
+[49e083af-47ec-4018-b807-62ef411efed7]
+description = "second Monday of March 2013"
+include = true
+
+[6cb79a73-38fe-4475-9101-9eec36cf79e5]
+description = "second Monday of April 2013"
+include = true
+
+[4c39b594-af7e-4445-aa03-bf4f8effd9a1]
+description = "second Tuesday of May 2013"
+include = true
+
+[41b32c34-2e39-40e3-b790-93539aaeb6dd]
+description = "second Tuesday of June 2013"
+include = true
+
+[90a160c5-b5d9-4831-927f-63a78b17843d]
+description = "second Wednesday of July 2013"
+include = true
+
+[23b98ce7-8dd5-41a1-9310-ef27209741cb]
+description = "second Wednesday of August 2013"
+include = true
+
+[447f1960-27ca-4729-bc3f-f36043f43ed0]
+description = "second Thursday of September 2013"
+include = true
+
+[c9aa2687-300c-4e79-86ca-077849a81bde]
+description = "second Thursday of October 2013"
+include = true
+
+[a7e11ef3-6625-4134-acda-3e7195421c09]
+description = "second Friday of November 2013"
+include = true
+
+[8b420e5f-9290-4106-b5ae-022f3e2a3e41]
+description = "second Friday of December 2013"
+include = true
+
+[80631afc-fc11-4546-8b5f-c12aaeb72b4f]
+description = "second Saturday of January 2013"
+include = true
+
+[e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
+description = "second Saturday of February 2013"
+include = true
+
+[a57d59fd-1023-47ad-b0df-a6feb21b44fc]
+description = "second Sunday of March 2013"
+include = true
+
+[a829a8b0-abdd-4ad1-b66c-5560d843c91a]
+description = "second Sunday of April 2013"
+include = true
+
+[501a8a77-6038-4fc0-b74c-33634906c29d]
+description = "third Monday of March 2013"
+include = true
+
+[49e4516e-cf32-4a58-8bbc-494b7e851c92]
+description = "third Monday of April 2013"
+include = true
+
+[4db61095-f7c7-493c-85f1-9996ad3012c7]
+description = "third Tuesday of May 2013"
+include = true
+
+[714fc2e3-58d0-4b91-90fd-61eefd2892c0]
+description = "third Tuesday of June 2013"
+include = true
+
+[b08a051a-2c80-445b-9b0e-524171a166d1]
+description = "third Wednesday of July 2013"
+include = true
+
+[80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
+description = "third Wednesday of August 2013"
+include = true
+
+[fa52a299-f77f-4784-b290-ba9189fbd9c9]
+description = "third Thursday of September 2013"
+include = true
+
+[f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
+description = "third Thursday of October 2013"
+include = true
+
+[8900f3b0-801a-466b-a866-f42d64667abd]
+description = "third Friday of November 2013"
+include = true
+
+[538ac405-a091-4314-9ccd-920c4e38e85e]
+description = "third Friday of December 2013"
+include = true
+
+[244db35c-2716-4fa0-88ce-afd58e5cf910]
+description = "third Saturday of January 2013"
+include = true
+
+[dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
+description = "third Saturday of February 2013"
+include = true
+
+[be71dcc6-00d2-4b53-a369-cbfae55b312f]
+description = "third Sunday of March 2013"
+include = true
+
+[b7d2da84-4290-4ee6-a618-ee124ae78be7]
+description = "third Sunday of April 2013"
+include = true
+
+[4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
+description = "fourth Monday of March 2013"
+include = true
+
+[ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
+description = "fourth Monday of April 2013"
+include = true
+
+[eb714ef4-1656-47cc-913c-844dba4ebddd]
+description = "fourth Tuesday of May 2013"
+include = true
+
+[16648435-7937-4d2d-b118-c3e38fd084bd]
+description = "fourth Tuesday of June 2013"
+include = true
+
+[de062bdc-9484-437a-a8c5-5253c6f6785a]
+description = "fourth Wednesday of July 2013"
+include = true
+
+[c2ce6821-169c-4832-8d37-690ef5d9514a]
+description = "fourth Wednesday of August 2013"
+include = true
+
+[d462c631-2894-4391-a8e3-dbb98b7a7303]
+description = "fourth Thursday of September 2013"
+include = true
+
+[9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
+description = "fourth Thursday of October 2013"
+include = true
+
+[83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
+description = "fourth Friday of November 2013"
+include = true
+
+[de752d2a-a95e-48d2-835b-93363dac3710]
+description = "fourth Friday of December 2013"
+include = true
+
+[eedd90ad-d581-45db-8312-4c6dcf9cf560]
+description = "fourth Saturday of January 2013"
+include = true
+
+[669fedcd-912e-48c7-a0a1-228b34af91d0]
+description = "fourth Saturday of February 2013"
+include = true
+
+[648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
+description = "fourth Sunday of March 2013"
+include = true
+
+[f81321b3-99ab-4db6-9267-69c5da5a7823]
+description = "fourth Sunday of April 2013"
+include = true
+
+[1af5e51f-5488-4548-aee8-11d7d4a730dc]
+description = "last Monday of March 2013"
+include = true
+
+[f29999f2-235e-4ec7-9dab-26f137146526]
+description = "last Monday of April 2013"
+include = true
+
+[31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
+description = "last Tuesday of May 2013"
+include = true
+
+[8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
+description = "last Tuesday of June 2013"
+include = true
+
+[0e762194-672a-4bdf-8a37-1e59fdacef12]
+description = "last Wednesday of July 2013"
+include = true
+
+[5016386a-f24e-4bd7-b439-95358f491b66]
+description = "last Wednesday of August 2013"
+include = true
+
+[12ead1a5-cdf9-4192-9a56-2229e93dd149]
+description = "last Thursday of September 2013"
+include = true
+
+[7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
+description = "last Thursday of October 2013"
+include = true
+
+[e47a739e-b979-460d-9c8a-75c35ca2290b]
+description = "last Friday of November 2013"
+include = true
+
+[5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
+description = "last Friday of December 2013"
+include = true
+
+[61e54cba-76f3-4772-a2b1-bf443fda2137]
+description = "last Saturday of January 2013"
+include = true
+
+[8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
+description = "last Saturday of February 2013"
+include = true
+
+[0b63e682-f429-4d19-9809-4a45bd0242dc]
+description = "last Sunday of March 2013"
+include = true
+
+[5232307e-d3e3-4afc-8ba6-4084ad987c00]
+description = "last Sunday of April 2013"
+include = true
+
+[0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
+description = "last Wednesday of February 2012"
+include = true
+
+[fe0936de-7eee-4a48-88dd-66c07ab1fefc]
+description = "last Wednesday of December 2014"
+include = true
+
+[2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
+description = "last Sunday of February 2015"
+include = true
+
+[00c3ce9f-cf36-4b70-90d8-92b32be6830e]
+description = "first Friday of December 2012"
+include = true

--- a/exercises/practice/nth-prime/.meta/tests.toml
+++ b/exercises/practice/nth-prime/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# first prime
-"75c65189-8aef-471a-81de-0a90c728160c" = true
+[75c65189-8aef-471a-81de-0a90c728160c]
+description = "first prime"
+include = true
 
-# second prime
-"2c38804c-295f-4701-b728-56dea34fd1a0" = true
+[2c38804c-295f-4701-b728-56dea34fd1a0]
+description = "second prime"
+include = true
 
-# sixth prime
-"56692534-781e-4e8c-b1f9-3e82c1640259" = true
+[56692534-781e-4e8c-b1f9-3e82c1640259]
+description = "sixth prime"
+include = true
 
-# big prime
-"fce1e979-0edb-412d-93aa-2c744e8f50ff" = true
+[fce1e979-0edb-412d-93aa-2c744e8f50ff]
+description = "big prime"
+include = true
 
-# there is no zeroth prime
-"bd0a9eae-6df7-485b-a144-80e13c7d55b2" = true
+[bd0a9eae-6df7-485b-a144-80e13c7d55b2]
+description = "there is no zeroth prime"
+include = true

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strand
-"3e5c30a8-87e2-4845-a815-a49671ade970" = true
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+include = true
 
-# can count one nucleotide in single-character input
-"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+include = true
 
-# strand with repeated nucleotide
-"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+include = true
 
-# strand with multiple nucleotides
-"40a45eac-c83f-4740-901a-20b22d15a39f" = true
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+include = true
 
-# strand with invalid nucleotides
-"b4c47851-ee9e-4b0a-be70-a86e343bd851" = true
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"
+include = true

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = true
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+include = true
 
-# perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+include = true
 
-# only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+include = true
 
-# missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+include = true
 
-# missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+include = true
 
-# with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+include = true
 
-# with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+include = true
 
-# missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+include = true
 
-# mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+include = true
 
-# case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"
+include = true

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -1,25 +1,35 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero rows
-"9920ce55-9629-46d5-85d6-4201f4a4234d" = true
+[9920ce55-9629-46d5-85d6-4201f4a4234d]
+description = "zero rows"
+include = true
 
-# single row
-"70d643ce-a46d-4e93-af58-12d88dd01f21" = true
+[70d643ce-a46d-4e93-af58-12d88dd01f21]
+description = "single row"
+include = true
 
-# two rows
-"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
+[a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
+description = "two rows"
+include = true
 
-# three rows
-"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
+[97206a99-79ba-4b04-b1c5-3c0fa1e16925]
+description = "three rows"
+include = true
 
-# four rows
-"565a0431-c797-417c-a2c8-2935e01ce306" = true
+[565a0431-c797-417c-a2c8-2935e01ce306]
+description = "four rows"
+include = true
 
-# five rows
-"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+[06f9ea50-9f51-4eb2-b9a9-c00975686c27]
+description = "five rows"
+include = true
 
-# six rows
-"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+[c3912965-ddb4-46a9-848e-3363e6b00b13]
+description = "six rows"
+include = true
 
-# ten rows
-"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true
+[6cb26c66-7b57-4161-962c-81ec8c99f16b]
+description = "ten rows"
+include = true

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# cleans the number
-"79666dce-e0f1-46de-95a1-563802913c35" = true
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+include = true
 
-# cleans numbers with dots
-"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+include = true
 
-# cleans numbers with multiple spaces
-"08f94c34-9a37-46a2-a123-2a8e9727395d" = true
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+include = true
 
-# invalid when 9 digits
-"598d8432-0659-4019-a78b-1c6a73691d21" = true
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+include = true
 
-# invalid when 11 digits does not start with a 1
-"57061c72-07b5-431f-9766-d97da7c4399d" = true
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+include = true
 
-# valid when 11 digits and starting with 1
-"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+include = true
 
-# valid when 11 digits and starting with 1 even with punctuation
-"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+include = true
 
-# invalid when more than 11 digits
-"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = true
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+include = true
 
-# invalid with letters
-"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = true
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+include = true
 
-# invalid with punctuations
-"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+include = true
 
-# invalid if area code starts with 0
-"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+include = true
 
-# invalid if area code starts with 1
-"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+include = true
 
-# invalid if exchange code starts with 0
-"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+include = true
 
-# invalid if exchange code starts with 1
-"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+include = true
 
-# invalid if area code starts with 0 on valid 11-digit number
-"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+include = true
 
-# invalid if area code starts with 1 on valid 11-digit number
-"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+include = true
 
-# invalid if exchange code starts with 0 on valid 11-digit number
-"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+include = true
 
-# invalid if exchange code starts with 1 on valid 11-digit number
-"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"
+include = true

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -1,22 +1,31 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no factors
-"924fc966-a8f5-4288-82f2-6b9224819ccd" = true
+[924fc966-a8f5-4288-82f2-6b9224819ccd]
+description = "no factors"
+include = true
 
-# prime number
-"17e30670-b105-4305-af53-ddde182cb6ad" = true
+[17e30670-b105-4305-af53-ddde182cb6ad]
+description = "prime number"
+include = true
 
-# square of a prime
-"f59b8350-a180-495a-8fb1-1712fbee1158" = true
+[f59b8350-a180-495a-8fb1-1712fbee1158]
+description = "square of a prime"
+include = true
 
-# cube of a prime
-"bc8c113f-9580-4516-8669-c5fc29512ceb" = true
+[bc8c113f-9580-4516-8669-c5fc29512ceb]
+description = "cube of a prime"
+include = true
 
-# product of primes and non-primes
-"00485cd3-a3fe-4fbe-a64a-a4308fc1f870" = true
+[00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
+description = "product of primes and non-primes"
+include = true
 
-# product of primes
-"02251d54-3ca1-4a9b-85e1-b38f4b0ccb91" = true
+[02251d54-3ca1-4a9b-85e1-b38f4b0ccb91]
+description = "product of primes"
+include = true
 
-# factors include a large prime
-"070cf8dc-e202-4285-aa37-8d775c9cd473" = true
+[070cf8dc-e202-4285-aa37-8d775c9cd473]
+description = "factors include a large prime"
+include = true

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -1,70 +1,95 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Methionine RNA sequence
-"96d3d44f-34a2-4db4-84cd-fff523e069be" = true
+[96d3d44f-34a2-4db4-84cd-fff523e069be]
+description = "Methionine RNA sequence"
+include = true
 
-# Phenylalanine RNA sequence 1
-"1b4c56d8-d69f-44eb-be0e-7b17546143d9" = true
+[1b4c56d8-d69f-44eb-be0e-7b17546143d9]
+description = "Phenylalanine RNA sequence 1"
+include = true
 
-# Phenylalanine RNA sequence 2
-"81b53646-bd57-4732-b2cb-6b1880e36d11" = true
+[81b53646-bd57-4732-b2cb-6b1880e36d11]
+description = "Phenylalanine RNA sequence 2"
+include = true
 
-# Leucine RNA sequence 1
-"42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4" = true
+[42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
+description = "Leucine RNA sequence 1"
+include = true
 
-# Leucine RNA sequence 2
-"ac5edadd-08ed-40a3-b2b9-d82bb50424c4" = true
+[ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
+description = "Leucine RNA sequence 2"
+include = true
 
-# Serine RNA sequence 1
-"8bc36e22-f984-44c3-9f6b-ee5d4e73f120" = true
+[8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
+description = "Serine RNA sequence 1"
+include = true
 
-# Serine RNA sequence 2
-"5c3fa5da-4268-44e5-9f4b-f016ccf90131" = true
+[5c3fa5da-4268-44e5-9f4b-f016ccf90131]
+description = "Serine RNA sequence 2"
+include = true
 
-# Serine RNA sequence 3
-"00579891-b594-42b4-96dc-7ff8bf519606" = true
+[00579891-b594-42b4-96dc-7ff8bf519606]
+description = "Serine RNA sequence 3"
+include = true
 
-# Serine RNA sequence 4
-"08c61c3b-fa34-4950-8c4a-133945570ef6" = true
+[08c61c3b-fa34-4950-8c4a-133945570ef6]
+description = "Serine RNA sequence 4"
+include = true
 
-# Tyrosine RNA sequence 1
-"54e1e7d8-63c0-456d-91d2-062c72f8eef5" = true
+[54e1e7d8-63c0-456d-91d2-062c72f8eef5]
+description = "Tyrosine RNA sequence 1"
+include = true
 
-# Tyrosine RNA sequence 2
-"47bcfba2-9d72-46ad-bbce-22f7666b7eb1" = true
+[47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
+description = "Tyrosine RNA sequence 2"
+include = true
 
-# Cysteine RNA sequence 1
-"3a691829-fe72-43a7-8c8e-1bd083163f72" = true
+[3a691829-fe72-43a7-8c8e-1bd083163f72]
+description = "Cysteine RNA sequence 1"
+include = true
 
-# Cysteine RNA sequence 2
-"1b6f8a26-ca2f-43b8-8262-3ee446021767" = true
+[1b6f8a26-ca2f-43b8-8262-3ee446021767]
+description = "Cysteine RNA sequence 2"
+include = true
 
-# Tryptophan RNA sequence
-"1e91c1eb-02c0-48a0-9e35-168ad0cb5f39" = true
+[1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
+description = "Tryptophan RNA sequence"
+include = true
 
-# STOP codon RNA sequence 1
-"e547af0b-aeab-49c7-9f13-801773a73557" = true
+[e547af0b-aeab-49c7-9f13-801773a73557]
+description = "STOP codon RNA sequence 1"
+include = true
 
-# STOP codon RNA sequence 2
-"67640947-ff02-4f23-a2ef-816f8a2ba72e" = true
+[67640947-ff02-4f23-a2ef-816f8a2ba72e]
+description = "STOP codon RNA sequence 2"
+include = true
 
-# STOP codon RNA sequence 3
-"9c2ad527-ebc9-4ace-808b-2b6447cb54cb" = true
+[9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
+description = "STOP codon RNA sequence 3"
+include = true
 
-# Translate RNA strand into correct protein list
-"d0f295df-fb70-425c-946c-ec2ec185388e" = true
+[d0f295df-fb70-425c-946c-ec2ec185388e]
+description = "Translate RNA strand into correct protein list"
+include = true
 
-# Translation stops if STOP codon at beginning of sequence
-"e30e8505-97ec-4e5f-a73e-5726a1faa1f4" = true
+[e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
+description = "Translation stops if STOP codon at beginning of sequence"
+include = true
 
-# Translation stops if STOP codon at end of two-codon sequence
-"5358a20b-6f4c-4893-bce4-f929001710f3" = true
+[5358a20b-6f4c-4893-bce4-f929001710f3]
+description = "Translation stops if STOP codon at end of two-codon sequence"
+include = true
 
-# Translation stops if STOP codon at end of three-codon sequence
-"ba16703a-1a55-482f-bb07-b21eef5093a3" = true
+[ba16703a-1a55-482f-bb07-b21eef5093a3]
+description = "Translation stops if STOP codon at end of three-codon sequence"
+include = true
 
-# Translation stops if STOP codon in middle of three-codon sequence
-"4089bb5a-d5b4-4e71-b79e-b8d1f14a2911" = true
+[4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
+description = "Translation stops if STOP codon in middle of three-codon sequence"
+include = true
 
-# Translation stops if STOP codon in middle of six-codon sequence
-"2c2a2a60-401f-4a80-b977-e0715b23b93d" = true
+[2c2a2a60-401f-4a80-b977-e0715b23b93d]
+description = "Translation stops if STOP codon in middle of six-codon sequence"
+include = true

--- a/exercises/practice/queen-attack/.meta/tests.toml
+++ b/exercises/practice/queen-attack/.meta/tests.toml
@@ -1,37 +1,51 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# queen with a valid position
-"3ac4f735-d36c-44c4-a3e2-316f79704203" = true
+[3ac4f735-d36c-44c4-a3e2-316f79704203]
+description = "queen with a valid position"
+include = true
 
-# queen must have positive row
-"4e812d5d-b974-4e38-9a6b-8e0492bfa7be" = true
+[4e812d5d-b974-4e38-9a6b-8e0492bfa7be]
+description = "queen must have positive row"
+include = true
 
-# queen must have row on board
-"f07b7536-b66b-4f08-beb9-4d70d891d5c8" = true
+[f07b7536-b66b-4f08-beb9-4d70d891d5c8]
+description = "queen must have row on board"
+include = true
 
-# queen must have positive column
-"15a10794-36d9-4907-ae6b-e5a0d4c54ebe" = true
+[15a10794-36d9-4907-ae6b-e5a0d4c54ebe]
+description = "queen must have positive column"
+include = true
 
-# queen must have column on board
-"6907762d-0e8a-4c38-87fb-12f2f65f0ce4" = true
+[6907762d-0e8a-4c38-87fb-12f2f65f0ce4]
+description = "queen must have column on board"
+include = true
 
-# can not attack
-"33ae4113-d237-42ee-bac1-e1e699c0c007" = true
+[33ae4113-d237-42ee-bac1-e1e699c0c007]
+description = "can not attack"
+include = true
 
-# can attack on same row
-"eaa65540-ea7c-4152-8c21-003c7a68c914" = true
+[eaa65540-ea7c-4152-8c21-003c7a68c914]
+description = "can attack on same row"
+include = true
 
-# can attack on same column
-"bae6f609-2c0e-4154-af71-af82b7c31cea" = true
+[bae6f609-2c0e-4154-af71-af82b7c31cea]
+description = "can attack on same column"
+include = true
 
-# can attack on first diagonal
-"0e1b4139-b90d-4562-bd58-dfa04f1746c7" = true
+[0e1b4139-b90d-4562-bd58-dfa04f1746c7]
+description = "can attack on first diagonal"
+include = true
 
-# can attack on second diagonal
-"ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd" = true
+[ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd]
+description = "can attack on second diagonal"
+include = true
 
-# can attack on third diagonal
-"0a71e605-6e28-4cc2-aa47-d20a2e71037a" = true
+[0a71e605-6e28-4cc2-aa47-d20a2e71037a]
+description = "can attack on third diagonal"
+include = true
 
-# can attack on fourth diagonal
-"0790b588-ae73-4f1f-a968-dd0b34f45f86" = true
+[0790b588-ae73-4f1f-a968-dd0b34f45f86]
+description = "can attack on fourth diagonal"
+include = true

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+include = true
 
-# the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+include = true
 
-# the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+include = true
 
-# the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+include = true
 
-# the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+include = true
 
-# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+include = true
 
-# the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+include = true
 
-# the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+include = true
 
-# the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+include = true
 
-# the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+include = true
 
-# the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+include = true
 
-# the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+include = true
 
-# the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+include = true
 
-# the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+include = true
 
-# the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+include = true
 
-# the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+include = true
 
-# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+include = true
 
-# the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"
+include = true

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,19 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# an empty string
-"c3b7d806-dced-49ee-8543-933fd1719b1c" = true
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+include = true
 
-# a word
-"01ebf55b-bebb-414e-9dec-06f7bb0bee3c" = true
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+include = true
 
-# a capitalized word
-"0f7c07e4-efd1-4aaa-a07a-90b49ce0b746" = true
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+include = true
 
-# a sentence with punctuation
-"71854b9c-f200-4469-9f5c-1e8e5eff5614" = true
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+include = true
 
-# a palindrome
-"1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c" = true
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+include = true
 
-# an even-sized word
-"b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c" = true
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"
+include = true

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,19 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+include = true
 
-# RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+include = true
 
-# RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+include = true
 
-# RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+include = true
 
-# RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+include = true
 
-# RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = true
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"
+include = true

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+[c557c16d-26c1-4e06-827c-f6602cd0785c]
+description = "at origin facing north"
+include = true
 
-# at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+[bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
+description = "at negative position facing south"
+include = true
 
-# changes north to east
-"8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
+[8cbd0086-6392-4680-b9b9-73cf491e67e5]
+description = "changes north to east"
+include = true
 
-# changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+[8abc87fc-eab2-4276-93b7-9c009e866ba1]
+description = "changes east to south"
+include = true
 
-# changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+[3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
+description = "changes south to west"
+include = true
 
-# changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+[5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
+description = "changes west to north"
+include = true
 
-# changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+[fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
+description = "changes north to west"
+include = true
 
-# changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+[da33d734-831f-445c-9907-d66d7d2a92e2]
+description = "changes west to south"
+include = true
 
-# changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+[bd1ca4b9-4548-45f4-b32e-900fc7c19389]
+description = "changes south to east"
+include = true
 
-# changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+[2de27b67-a25c-4b59-9883-bc03b1b55bba]
+description = "changes east to north"
+include = true
 
-# facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+[f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
+description = "facing north increments Y"
+include = true
 
-# facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+[2786cf80-5bbf-44b0-9503-a89a9c5789da]
+description = "facing south decrements Y"
+include = true
 
-# facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+[84bf3c8c-241f-434d-883d-69817dbd6a48]
+description = "facing east increments X"
+include = true
 
-# facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+[bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
+description = "facing west decrements X"
+include = true
 
-# moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+[e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
+description = "moving east and north from README"
+include = true
 
-# moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+[f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
+description = "moving west and north"
+include = true
 
-# moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+[3e466bf6-20ab-4d79-8b51-264165182fca]
+description = "moving west and south"
+include = true
 
-# moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = true
+[41f0bb96-c617-4e6b-acff-a4b279d44514]
+description = "moving east and north"
+include = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,58 +1,79 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1 is a single I
-"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is a single I"
+include = true
 
-# 2 is two I's
-"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is two I's"
+include = true
 
-# 3 is three I's
-"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is three I's"
+include = true
 
-# 4, being 5 - 1, is IV
-"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4, being 5 - 1, is IV"
+include = true
 
-# 5 is a single V
-"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is a single V"
+include = true
 
-# 6, being 5 + 1, is VI
-"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6, being 5 + 1, is VI"
+include = true
 
-# 9, being 10 - 1, is IX
-"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9, being 10 - 1, is IX"
+include = true
 
-# 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "20 is two X's"
+include = true
 
-# 48 is not 50 - 2 but rather 40 + 8
-"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is not 50 - 2 but rather 40 + 8"
+include = true
 
-# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
+include = true
 
-# 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "50 is a single L"
+include = true
 
-# 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "90, being 100 - 10, is XC"
+include = true
 
-# 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "100 is a single C"
+include = true
 
-# 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "60, being 50 + 10, is LX"
+include = true
 
-# 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "400, being 500 - 100, is CD"
+include = true
 
-# 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "500 is a single D"
+include = true
 
-# 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "900, being 1000 - 100, is CM"
+include = true
 
-# 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1000 is a single M"
+include = true
 
-# 3000 is three M's
-"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is three M's"
+include = true

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -1,46 +1,63 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero
-"5d22a120-ba0c-428c-bd25-8682235d83e8" = true
+[5d22a120-ba0c-428c-bd25-8682235d83e8]
+description = "zero"
+include = true
 
-# one
-"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = true
+[9b5eed77-dbf6-439d-b920-3f7eb58928f6]
+description = "one"
+include = true
 
-# fourteen
-"7c499be1-612e-4096-a5e1-43b2f719406d" = true
+[7c499be1-612e-4096-a5e1-43b2f719406d]
+description = "fourteen"
+include = true
 
-# twenty
-"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
+[f541dd8e-f070-4329-92b4-b7ce2fcf06b4]
+description = "twenty"
+include = true
 
-# twenty-two
-"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = true
+[d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
+description = "twenty-two"
+include = true
 
-# one hundred
-"e417d452-129e-4056-bd5b-6eb1df334dce" = true
+[e417d452-129e-4056-bd5b-6eb1df334dce]
+description = "one hundred"
+include = true
 
-# one hundred twenty-three
-"d6924f30-80ba-4597-acf6-ea3f16269da8" = true
+[d6924f30-80ba-4597-acf6-ea3f16269da8]
+description = "one hundred twenty-three"
+include = true
 
-# one thousand
-"3d83da89-a372-46d3-b10d-de0c792432b3" = true
+[3d83da89-a372-46d3-b10d-de0c792432b3]
+description = "one thousand"
+include = true
 
-# one thousand two hundred thirty-four
-"865af898-1d5b-495f-8ff0-2f06d3c73709" = true
+[865af898-1d5b-495f-8ff0-2f06d3c73709]
+description = "one thousand two hundred thirty-four"
+include = true
 
-# one million
-"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = true
+[b6a3f442-266e-47a3-835d-7f8a35f6cf7f]
+description = "one million"
+include = true
 
-# one million two thousand three hundred forty-five
-"2cea9303-e77e-4212-b8ff-c39f1978fc70" = true
+[2cea9303-e77e-4212-b8ff-c39f1978fc70]
+description = "one million two thousand three hundred forty-five"
+include = true
 
-# one billion
-"3e240eeb-f564-4b80-9421-db123f66a38f" = true
+[3e240eeb-f564-4b80-9421-db123f66a38f]
+description = "one billion"
+include = true
 
-# a big number
-"9a43fed1-c875-4710-8286-5065d73b8a9e" = true
+[9a43fed1-c875-4710-8286-5065d73b8a9e]
+description = "a big number"
+include = true
 
-# numbers below zero are out of range
-"49a6a17b-084e-423e-994d-a87c0ecc05ef" = true
+[49a6a17b-084e-423e-994d-a87c0ecc05ef]
+description = "numbers below zero are out of range"
+include = true
 
-# numbers above 999,999,999,999 are out of range
-"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = true
+[4d6492eb-5853-4d16-9d34-b0f61b261fd9]
+description = "numbers above 999,999,999,999 are out of range"
+include = true

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# lowercase letter
-"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = true
+[f46cda29-1ca5-4ef2-bd45-388a767e3db2]
+description = "lowercase letter"
+include = true
 
-# uppercase letter
-"f7794b49-f13e-45d1-a933-4e48459b2201" = true
+[f7794b49-f13e-45d1-a933-4e48459b2201]
+description = "uppercase letter"
+include = true
 
-# valuable letter
-"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = true
+[eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
+description = "valuable letter"
+include = true
 
-# short word
-"f3c8c94e-bb48-4da2-b09f-e832e103151e" = true
+[f3c8c94e-bb48-4da2-b09f-e832e103151e]
+description = "short word"
+include = true
 
-# short, valuable word
-"71e3d8fa-900d-4548-930e-68e7067c4615" = true
+[71e3d8fa-900d-4548-930e-68e7067c4615]
+description = "short, valuable word"
+include = true
 
-# medium word
-"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
+[d3088ad9-570c-4b51-8764-c75d5a430e99]
+description = "medium word"
+include = true
 
-# medium, valuable word
-"fa20c572-ad86-400a-8511-64512daac352" = true
+[fa20c572-ad86-400a-8511-64512daac352]
+description = "medium, valuable word"
+include = true
 
-# long, mixed-case word
-"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = true
+[9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
+description = "long, mixed-case word"
+include = true
 
-# english-like word
-"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = true
+[1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
+description = "english-like word"
+include = true
 
-# empty input
-"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = true
+[4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
+description = "empty input"
+include = true
 
-# entire alphabet available
-"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = true
+[3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
+description = "entire alphabet available"
+include = true

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# wink for 1
-"b8496fbd-6778-468c-8054-648d03c4bb23" = true
+[b8496fbd-6778-468c-8054-648d03c4bb23]
+description = "wink for 1"
+include = true
 
-# double blink for 10
-"83ec6c58-81a9-4fd1-bfaf-0160514fc0e3" = true
+[83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
+description = "double blink for 10"
+include = true
 
-# close your eyes for 100
-"0e20e466-3519-4134-8082-5639d85fef71" = true
+[0e20e466-3519-4134-8082-5639d85fef71]
+description = "close your eyes for 100"
+include = true
 
-# jump for 1000
-"b339ddbb-88b7-4b7d-9b19-4134030d9ac0" = true
+[b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
+description = "jump for 1000"
+include = true
 
-# combine two actions
-"40499fb4-e60c-43d7-8b98-0de3ca44e0eb" = true
+[40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
+description = "combine two actions"
+include = true
 
-# reverse two actions
-"9730cdd5-ef27-494b-afd3-5c91ad6c3d9d" = true
+[9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
+description = "reverse two actions"
+include = true
 
-# reversing one action gives the same action
-"0b828205-51ca-45cd-90d5-f2506013f25f" = true
+[0b828205-51ca-45cd-90d5-f2506013f25f]
+description = "reversing one action gives the same action"
+include = true
 
-# reversing no actions still gives no actions
-"9949e2ac-6c9c-4330-b685-2089ab28b05f" = true
+[9949e2ac-6c9c-4330-b685-2089ab28b05f]
+description = "reversing no actions still gives no actions"
+include = true
 
-# all possible actions
-"23fdca98-676b-4848-970d-cfed7be39f81" = true
+[23fdca98-676b-4848-970d-cfed7be39f81]
+description = "all possible actions"
+include = true
 
-# reverse all possible actions
-"ae8fe006-d910-4d6f-be00-54b7c3799e79" = true
+[ae8fe006-d910-4d6f-be00-54b7c3799e79]
+description = "reverse all possible actions"
+include = true
 
-# do nothing for zero
-"3d36da37-b31f-4cdb-a396-d93a2ee1c4a5" = true
+[3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
+description = "do nothing for zero"
+include = true

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# slices of one from one
-"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
+[7ae7a46a-d992-4c2a-9c15-a112d125ebad]
+description = "slices of one from one"
+include = true
 
-# slices of one from two
-"3143b71d-f6a5-4221-aeae-619f906244d2" = true
+[3143b71d-f6a5-4221-aeae-619f906244d2]
+description = "slices of one from two"
+include = true
 
-# slices of two
-"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = true
+[dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
+description = "slices of two"
+include = true
 
-# slices of two overlap
-"19bbea47-c987-4e11-a7d1-e103442adf86" = true
+[19bbea47-c987-4e11-a7d1-e103442adf86]
+description = "slices of two overlap"
+include = true
 
-# slices can include duplicates
-"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
+[8e17148d-ba0a-4007-a07f-d7f87015d84c]
+description = "slices can include duplicates"
+include = true
 
-# slices of a long series
-"bd5b085e-f612-4f81-97a8-6314258278b0" = true
+[bd5b085e-f612-4f81-97a8-6314258278b0]
+description = "slices of a long series"
+include = true
 
-# slice length is too large
-"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
+[6d235d85-46cf-4fae-9955-14b6efef27cd]
+description = "slice length is too large"
+include = true
 
-# slice length cannot be zero
-"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
+[d34004ad-8765-4c09-8ba1-ada8ce776806]
+description = "slice length cannot be zero"
+include = true
 
-# slice length cannot be negative
-"10ab822d-8410-470a-a85d-23fbeb549e54" = true
+[10ab822d-8410-470a-a85d-23fbeb549e54]
+description = "slice length cannot be negative"
+include = true
 
-# empty series is invalid
-"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true
+[c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
+description = "empty series is invalid"
+include = true

--- a/exercises/practice/sieve/.meta/tests.toml
+++ b/exercises/practice/sieve/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no primes under two
-"88529125-c4ce-43cc-bb36-1eb4ddd7b44f" = true
+[88529125-c4ce-43cc-bb36-1eb4ddd7b44f]
+description = "no primes under two"
+include = true
 
-# find first prime
-"4afe9474-c705-4477-9923-840e1024cc2b" = true
+[4afe9474-c705-4477-9923-840e1024cc2b]
+description = "find first prime"
+include = true
 
-# find primes up to 10
-"974945d8-8cd9-4f00-9463-7d813c7f17b7" = true
+[974945d8-8cd9-4f00-9463-7d813c7f17b7]
+description = "find primes up to 10"
+include = true
 
-# limit is prime
-"2e2417b7-3f3a-452a-8594-b9af08af6d82" = true
+[2e2417b7-3f3a-452a-8594-b9af08af6d82]
+description = "limit is prime"
+include = true
 
-# find primes up to 1000
-"92102a05-4c7c-47de-9ed0-b7d5fcd00f21" = true
+[92102a05-4c7c-47de-9ed0-b7d5fcd00f21]
+description = "find primes up to 1000"
+include = true

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,25 +1,35 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+include = true
 
-# age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+include = true
 
-# age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+include = true
 
-# age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+include = true
 
-# age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+include = true
 
-# age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+include = true
 
-# age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+include = true
 
-# age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"
+include = true

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,67 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no multiples within limit
-"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+[54aaab5a-ce86-4edc-8b40-d3ab2400a279]
+description = "no multiples within limit"
+include = true
 
-# one factor has multiples within limit
-"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+[361e4e50-c89b-4f60-95ef-5bc5c595490a]
+description = "one factor has multiples within limit"
+include = true
 
-# more than one multiple within limit
-"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+[e644e070-040e-4ae0-9910-93c69fc3f7ce]
+description = "more than one multiple within limit"
+include = true
 
-# more than one factor with multiples within limit
-"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+[607d6eb9-535c-41ce-91b5-3a61da3fa57f]
+description = "more than one factor with multiples within limit"
+include = true
 
-# each multiple is only counted once
-"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+[f47e8209-c0c5-4786-b07b-dc273bf86b9b]
+description = "each multiple is only counted once"
+include = true
 
-# a much larger limit
-"28c4b267-c980-4054-93e9-07723db615ac" = true
+[28c4b267-c980-4054-93e9-07723db615ac]
+description = "a much larger limit"
+include = true
 
-# three factors
-"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+[09c4494d-ff2d-4e0f-8421-f5532821ee12]
+description = "three factors"
+include = true
 
-# factors not relatively prime
-"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+[2d0d5faa-f177-4ad6-bde9-ebb865083751]
+description = "factors not relatively prime"
+include = true
 
-# some pairs of factors relatively prime and some not
-"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+[ece8f2e8-96aa-4166-bbb7-6ce71261e354]
+description = "some pairs of factors relatively prime and some not"
+include = true
 
-# one factor is a multiple of another
-"624fdade-6ffb-400e-8472-456a38c171c0" = true
+[624fdade-6ffb-400e-8472-456a38c171c0]
+description = "one factor is a multiple of another"
+include = true
 
-# much larger factors
-"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+[949ee7eb-db51-479c-b5cb-4a22b40ac057]
+description = "much larger factors"
+include = true
 
-# all numbers are multiples of 1
-"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+[41093673-acbd-482c-ab80-d00a0cbedecd]
+description = "all numbers are multiples of 1"
+include = true
 
-# no factors means an empty sum
-"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+[1730453b-baaa-438e-a9c2-d754497b2a76]
+description = "no factors means an empty sum"
+include = true
 
-# the only multiple of 0 is 0
-"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+[214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
+description = "the only multiple of 0 is 0"
+include = true
 
-# the factor 0 does not affect the sum of multiples of other factors
-"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+[c423ae21-a0cb-4ec7-aeb1-32971af5b510]
+description = "the factor 0 does not affect the sum of multiples of other factors"
+include = true
 
-# solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = true
+[17053ba9-112f-4ac0-aadb-0519dd836342]
+description = "solutions using include-exclude must extend to cardinality greater than 3"
+include = true

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,58 +1,79 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# all sides are equal
-"8b2c43ac-7257-43f9-b552-7631a91988af" = true
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "all sides are equal"
+include = true
 
-# any side is unequal
-"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = true
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "any side is unequal"
+include = true
 
-# no sides are equal
-"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "no sides are equal"
+include = true
 
-# all zero sides is not a triangle
-"16e8ceb0-eadb-46d1-b892-c50327479251" = true
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "all zero sides is not a triangle"
+include = true
 
-# sides may be floats
-"3022f537-b8e5-4cc1-8f12-fd775827a00c" = true
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "sides may be floats"
+include = true
 
-# last two sides are equal
-"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = true
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "last two sides are equal"
+include = true
 
-# first two sides are equal
-"e388ce93-f25e-4daf-b977-4b7ede992217" = true
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "first two sides are equal"
+include = true
 
-# first and last sides are equal
-"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = true
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "first and last sides are equal"
+include = true
 
-# equilateral triangles are also isosceles
-"8d71e185-2bd7-4841-b7e1-71689a5491d8" = true
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "equilateral triangles are also isosceles"
+include = true
 
-# no sides are equal
-"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = true
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "no sides are equal"
+include = true
 
-# first triangle inequality violation
-"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "first triangle inequality violation"
+include = true
 
-# second triangle inequality violation
-"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "second triangle inequality violation"
+include = true
 
-# third triangle inequality violation
-"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "third triangle inequality violation"
+include = true
 
-# sides may be floats
-"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = true
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "sides may be floats"
+include = true
 
-# no sides are equal
-"e8b5f09c-ec2e-47c1-abec-f35095733afb" = true
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "no sides are equal"
+include = true
 
-# all sides are equal
-"2510001f-b44d-4d18-9872-2303e7977dc1" = true
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "all sides are equal"
+include = true
 
-# two sides are equal
-"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = true
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "two sides are equal"
+include = true
 
-# may not violate triangle inequality
-"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "may not violate triangle inequality"
+include = true
 
-# sides may be floats
-"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = true
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "sides may be floats"
+include = true

--- a/exercises/practice/trinary/.meta/tests.toml
+++ b/exercises/practice/trinary/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# trinary 1 is decimal 1
-"a7a79a9e-5606-454c-9cdb-4f3c0ca46931" = true
+[a7a79a9e-5606-454c-9cdb-4f3c0ca46931]
+description = "trinary 1 is decimal 1"
+include = true
 
-# trinary 2 is decimal 2
-"39240078-13e2-4eb8-87c4-aeffa7d64130" = true
+[39240078-13e2-4eb8-87c4-aeffa7d64130]
+description = "trinary 2 is decimal 2"
+include = true
 
-# trinary 10 is decimal 3
-"81900d67-7e07-4d41-a71e-86f1cd72ce1f" = true
+[81900d67-7e07-4d41-a71e-86f1cd72ce1f]
+description = "trinary 10 is decimal 3"
+include = true
 
-# trinary 11 is decimal 4
-"7a8d5341-f88a-4c60-9048-4d5e017fa701" = true
+[7a8d5341-f88a-4c60-9048-4d5e017fa701]
+description = "trinary 11 is decimal 4"
+include = true
 
-# trinary 100 is decimal 9
-"6b3c37f6-d6b3-4575-85c0-19f48dd101af" = true
+[6b3c37f6-d6b3-4575-85c0-19f48dd101af]
+description = "trinary 100 is decimal 9"
+include = true
 
-# trinary 112 is decimal 14
-"a210b2b8-d333-4e19-9e59-87cabdd2a0ba" = true
+[a210b2b8-d333-4e19-9e59-87cabdd2a0ba]
+description = "trinary 112 is decimal 14"
+include = true
 
-# trinary 222 is decimal 26
-"5ae03472-b942-42ce-ba00-e84a7dc86dd8" = true
+[5ae03472-b942-42ce-ba00-e84a7dc86dd8]
+description = "trinary 222 is decimal 26"
+include = true
 
-# trinary 1122000120 is decimal 32091
-"d4fabf94-6149-4d1e-b42f-b34dc3ddef8f" = true
+[d4fabf94-6149-4d1e-b42f-b34dc3ddef8f]
+description = "trinary 1122000120 is decimal 32091"
+include = true
 
-# invalid trinary digits returns 0
-"34be152d-38f3-4dcf-b5ab-9e14fe2f7161" = true
+[34be152d-38f3-4dcf-b5ab-9e14fe2f7161]
+description = "invalid trinary digits returns 0"
+include = true
 
-# invalid word as input returns 0
-"b57aa24d-3da2-4787-9429-5bc94d3112d6" = true
+[b57aa24d-3da2-4787-9429-5bc94d3112d6]
+description = "invalid word as input returns 0"
+include = true
 
-# invalid numbers with letters as input returns 0
-"673c2057-5d89-483c-87fa-139da6927b90" = true
+[673c2057-5d89-483c-87fa-139da6927b90]
+description = "invalid numbers with letters as input returns 0"
+include = true

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,10 +1,15 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+include = true
 
-# a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+include = true
 
-# another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"
+include = true

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,40 +1,55 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# count one word
-"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+include = true
 
-# count one of each word
-"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+include = true
 
-# multiple occurrences of a word
-"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+include = true
 
-# handles cramped lists
-"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+include = true
 
-# handles expanded lists
-"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+include = true
 
-# ignore punctuation
-"a514a0f2-8589-4279-8892-887f76a14c82" = true
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+include = true
 
-# include numbers
-"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+include = true
 
-# normalize case
-"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+include = true
 
-# with apostrophes
-"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+include = true
 
-# with quotations
-"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+include = true
 
-# substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+include = true
 
-# multiple spaces not detected as a word
-"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+include = true
 
-# alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"
+include = true


### PR DESCRIPTION
Track maintainers found that they wanted to add comments to the tests.toml file to e.g. indicate _why_ a test was not included.
Unfortunately, running configlet sync would re-generate the entire file so any manually added comments were lost.

In this PR we're updating the format of tests.toml files to support adding comments.
We do this by creating a separate table for each test case which has `description` and `include` fields.
Tracks are then free to add additional fields, like a `comment` field, but also any other fields they feel might be useful to them.

configlet has _not_ yet been updated to support this new format, but we hope to do this soon. Sorry for the inconvenience.

For more information, see this discussion: https://github.com/exercism/configlet/issues/186

## Implementation

The PR expects the tests.toml files to be in their original format:

```toml
# <description>
"<uuid>" = <include>
```

This is transformed to:

```toml
[<uuid>]
description = "<description>"
include = <include>
```

## Example

```toml
# one factor has multiples within limit
"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
```

becomes

```toml
[361e4e50-c89b-4f60-95ef-5bc5c595490a]
description = "one factor has multiples within limit"
include = true
```

## Existing comments

As some tracks have manually added comments to tests, we try to detect them by assuming they are either:

- Added as a line comment _before_ the description (we'll ignore empty lines)
- Added as an inline comment _after_ boolean include value

For any such manually detected comments, we'll add a `comment` field.

## Tracking

https://github.com/exercism/v3-launch/issues/22
