### PR TITLE
Removing configlet lint from critical CI path.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,12 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
-  configuration-test:
-    name: Check Configuration
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Configlet
-      run: |
-        bin/fetch-configlet
-        bin/configlet lint .
-        bin/check-configlet-fmt.sh
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   linux-min:
     name: Linux Min Config
     runs-on: ubuntu-16.04
@@ -44,7 +31,7 @@ jobs:
 
   linux-latest:
     name: Linux Latest Config
-    needs: [linux-min, configuration-test]
+    needs: [linux-min]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,7 +61,7 @@ jobs:
 
   windows:
     name: Windows
-    needs: [linux-min, configuration-test]
+    needs: [linux-min]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
@@ -90,7 +77,7 @@ jobs:
 
   mac:
     name: MacOS
-    needs: [linux-min, configuration-test]
+    needs: [linux-min]
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
       shell: powershell
       # Delete the exercises that require Boost to avoid issues with Windows setup.
       run: |
-        rm exercises/gigasecond -r
-        rm exercises/meetup -r
+        rm exercises/practice/gigasecond -r
+        rm exercises/practice/meetup -r
         cmake .
         cmake --build . -- test_hello-world
         cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(exercism CXX)
 
-set(alt_exercise_tree ${CMAKE_CURRENT_SOURCE_DIR}/build_exercises)
+set(alt_exercise_tree ${CMAKE_CURRENT_SOURCE_DIR}/build_exercises/practice)
 
 function(build_fixup exercise_dir alt_exercise_root)
     string(REPLACE "-" "_" file ${exercise_dir})
-    set(source ${CMAKE_CURRENT_SOURCE_DIR}/exercises/${exercise_dir})
+    set(source ${CMAKE_CURRENT_SOURCE_DIR}/exercises/practice/${exercise_dir})
     if(EXISTS ${source})
         set(alt_exercise_dir ${alt_exercise_root}/${exercise_dir})
         file(COPY ${source} DESTINATION ${alt_exercise_root})
@@ -30,7 +30,7 @@ if(EXERCISM_COMMON_CATCH)
     )
 endif()
 
-file(GLOB exercise_list ${CMAKE_CURRENT_SOURCE_DIR}/exercises/*)
+file(GLOB exercise_list ${CMAKE_CURRENT_SOURCE_DIR}/exercises/practice/*)
 
 foreach(exercise_dir ${exercise_list})
     get_filename_component(exercise ${exercise_dir} NAME)

--- a/config.json
+++ b/config.json
@@ -717,5 +717,25 @@
     }
   ],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "execution_mode/compiled",
+    "paradigm/procedural",
+    "typing/static",
+    "platform/android",
+    "platform/ios",
+    "platform/linux",
+    "platform/mac",
+    "platform/windows",
+    "runtime/language_specific",
+    "used_for/backends",
+    "used_for/cross_platform_development",
+    "used_for/embedded_systems",
+    "used_for/financial_systems",
+    "used_for/frontends",
+    "used_for/games",
+    "used_for/guis",
+    "used_for/mobile",
+    "used_for/robotics",
+    "used_for/scientific_calculations"
+  ]
 }

--- a/exercises/concept/strings/.meta/config.json
+++ b/exercises/concept/strings/.meta/config.json
@@ -7,8 +7,8 @@
   ],
   "forked_from": ["csharp/strings"],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": ["strings.cpp", "strings.h"],
+    "test": ["strings_test.cpp"],
     "exemplar": [".meta/exemplar.cpp", ".meta/exemplar.h"]
   }
 }


### PR DESCRIPTION
Configlet lint was configured as a prerequisite for CI. It should instead just be an FYI, and checked manually on any PRs for changes to the config file.

It still runs as a separate Github Action "Configlet CI".

As this is fixing our CI pipeline, which will unblock other changes, if I can I will just approve and merge this myself once it passes.

Passes the current linting checks #422 

Closes #420.
