### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "45840360-fa9a-45c0-9745-3d8cc7361866",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing C++ locally",
+      "blurb": "Learn how to install C++ locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "0540d25a-c656-46e2-a765-bc2df2ba4e1e",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn C++",
+      "blurb": "An overview of how to get started from scratch with C++"
+    },
+    {
+      "uuid": "7ce4762c-b20a-4e03-8b67-80d4f3287b38",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the C++ track",
+      "blurb": "Learn how to test your C++ exercises on Exercism"
+    },
+    {
+      "uuid": "ca771aaf-ff7f-43db-aea8-bd2e76ab661a",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful C++ resources",
+      "blurb": "A collection of useful resources to help you master C++"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
