### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -455,7 +455,7 @@
       {
         "slug": "complex-numbers",
         "name": "Complex Numbers",
-        "uuid": "ea8d6224-0440-6d80-1569-a04127908a200d2ecf0",
+        "uuid": "ab52f0fa-b884-4af2-9271-19349bed4b2e",
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
@@ -693,7 +693,7 @@
       {
         "slug": "all-your-base",
         "name": "All Your Base",
-        "uuid": "0a3220c6-07a9-ed80-4d2d-1fc65de969b771a46d5",
+        "uuid": "5a839eb7-cc4b-48eb-bd04-57ba6e77eae8",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
