### PR TITLE
Change all exercises to work with updated test runner

### DIFF
--- a/exercises/concept/strings/CMakeLists.txt
+++ b/exercises/concept/strings/CMakeLists.txt
@@ -28,13 +28,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/concept/strings/strings_test.cpp
+++ b/exercises/concept/strings/strings_test.cpp
@@ -1,5 +1,9 @@
 #include "strings.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/acronym/acronym_test.cpp
+++ b/exercises/practice/acronym/acronym_test.cpp
@@ -1,5 +1,9 @@
 #include "acronym.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/all-your-base/CMakeLists.txt
+++ b/exercises/practice/all-your-base/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/all-your-base/all_your_base_test.cpp
+++ b/exercises/practice/all-your-base/all_your_base_test.cpp
@@ -1,5 +1,9 @@
 #include "all_your_base.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/allergies/allergies_test.cpp
+++ b/exercises/practice/allergies/allergies_test.cpp
@@ -1,5 +1,9 @@
 #include "allergies.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 #include <string>
 #include <unordered_set>

--- a/exercises/practice/anagram/CMakeLists.txt
+++ b/exercises/practice/anagram/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/anagram/anagram_test.cpp
+++ b/exercises/practice/anagram/anagram_test.cpp
@@ -1,5 +1,9 @@
 #include "anagram.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/armstrong-numbers/armstrong_numbers_test.cpp
+++ b/exercises/practice/armstrong-numbers/armstrong_numbers_test.cpp
@@ -1,4 +1,8 @@
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include "armstrong_numbers.h"
 
 // Armstrong-numbers exercise test case data version 1.1.0

--- a/exercises/practice/atbash-cipher/CMakeLists.txt
+++ b/exercises/practice/atbash-cipher/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/atbash-cipher/atbash_cipher_test.cpp
+++ b/exercises/practice/atbash-cipher/atbash_cipher_test.cpp
@@ -1,5 +1,9 @@
 #include "atbash_cipher.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("encode_yes")
 {

--- a/exercises/practice/beer-song/CMakeLists.txt
+++ b/exercises/practice/beer-song/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/beer-song/beer_song_test.cpp
+++ b/exercises/practice/beer-song/beer_song_test.cpp
@@ -1,5 +1,9 @@
 #include "beer_song.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/binary-search-tree/CMakeLists.txt
+++ b/exercises/practice/binary-search-tree/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/binary-search-tree/binary_search_tree_test.cpp
+++ b/exercises/practice/binary-search-tree/binary_search_tree_test.cpp
@@ -1,5 +1,9 @@
 #include "binary_search_tree.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <vector>
 
 // test data version: 1.0.0

--- a/exercises/practice/binary-search/CMakeLists.txt
+++ b/exercises/practice/binary-search/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/binary-search/binary_search_test.cpp
+++ b/exercises/practice/binary-search/binary_search_test.cpp
@@ -1,5 +1,9 @@
 #include "binary_search.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <stdexcept>
 #include <vector>
 #include <cstddef>

--- a/exercises/practice/binary/CMakeLists.txt
+++ b/exercises/practice/binary/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/binary/binary_test.cpp
+++ b/exercises/practice/binary/binary_test.cpp
@@ -1,5 +1,9 @@
 #include "binary.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("b1_is_decimal_1")
 {

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/bob/bob_test.cpp
+++ b/exercises/practice/bob/bob_test.cpp
@@ -1,5 +1,9 @@
 #include "bob.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 // Bob exercise test case data version 1.4.0
 

--- a/exercises/practice/circular-buffer/CMakeLists.txt
+++ b/exercises/practice/circular-buffer/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/clock/CMakeLists.txt
+++ b/exercises/practice/clock/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/clock/clock_test.cpp
+++ b/exercises/practice/clock/clock_test.cpp
@@ -1,5 +1,9 @@
 #include "clock.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <sstream>
 
 using namespace std;

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/complex-numbers/CMakeLists.txt
+++ b/exercises/practice/complex-numbers/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/complex-numbers/complex_numbers_test.cpp
+++ b/exercises/practice/complex-numbers/complex_numbers_test.cpp
@@ -2,7 +2,11 @@
 
 #include <cmath>
 
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 // Complex Numbers exercise test case data version 1.3.0
 

--- a/exercises/practice/crypto-square/CMakeLists.txt
+++ b/exercises/practice/crypto-square/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/crypto-square/crypto_square_test.cpp
+++ b/exercises/practice/crypto-square/crypto_square_test.cpp
@@ -1,5 +1,9 @@
 #include "crypto_square.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("normalize_capitals")
 {

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/difference-of-squares/difference_of_squares_test.cpp
+++ b/exercises/practice/difference-of-squares/difference_of_squares_test.cpp
@@ -1,5 +1,9 @@
 #include "difference_of_squares.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("up_to_5")
 {

--- a/exercises/practice/etl/CMakeLists.txt
+++ b/exercises/practice/etl/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/etl/etl_test.cpp
+++ b/exercises/practice/etl/etl_test.cpp
@@ -1,6 +1,10 @@
 #include "etl.h"
 #include <map>
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("transforms_one_value")
 {

--- a/exercises/practice/food-chain/CMakeLists.txt
+++ b/exercises/practice/food-chain/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/food-chain/food_chain_test.cpp
+++ b/exercises/practice/food-chain/food_chain_test.cpp
@@ -1,5 +1,9 @@
 #include "food_chain.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -27,13 +27,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/gigasecond/gigasecond_test.cpp
+++ b/exercises/practice/gigasecond/gigasecond_test.cpp
@@ -1,5 +1,9 @@
 #include "gigasecond.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include "boost/date_time/posix_time/posix_time.hpp"
 
 // This problem requires you to install and use the boost date_time library.

--- a/exercises/practice/grade-school/CMakeLists.txt
+++ b/exercises/practice/grade-school/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/grade-school/grade_school_test.cpp
+++ b/exercises/practice/grade-school/grade_school_test.cpp
@@ -1,6 +1,10 @@
 #include "grade_school.h"
 #include <map>
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/grains/grains_test.cpp
+++ b/exercises/practice/grains/grains_test.cpp
@@ -1,5 +1,9 @@
 #include "grains.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("square_1")
 {

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/hamming/hamming_test.cpp
+++ b/exercises/practice/hamming/hamming_test.cpp
@@ -1,6 +1,10 @@
 #include "hamming.h"
 #include <stdexcept>
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("no_difference_between_identical_strands")
 {

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/hello-world/hello_world_test.cpp
+++ b/exercises/practice/hello-world/hello_world_test.cpp
@@ -2,7 +2,11 @@
 #include "hello_world.h"
 
 // Include the test framework.
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 // Declares a single test.
 TEST_CASE("test_hello")

--- a/exercises/practice/hexadecimal/CMakeLists.txt
+++ b/exercises/practice/hexadecimal/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/hexadecimal/hexadecimal_test.cpp
+++ b/exercises/practice/hexadecimal/hexadecimal_test.cpp
@@ -1,5 +1,9 @@
 #include "hexadecimal.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("hex_1_is_decimal_1")
 {

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/isogram/isogram_test.cpp
+++ b/exercises/practice/isogram/isogram_test.cpp
@@ -1,5 +1,9 @@
 #include "isogram.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 using namespace std;
 

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/leap/leap_test.cpp
+++ b/exercises/practice/leap/leap_test.cpp
@@ -1,5 +1,9 @@
 #include "leap.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("not_divisible_by_4")
 {

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/luhn/luhn_test.cpp
+++ b/exercises/practice/luhn/luhn_test.cpp
@@ -1,5 +1,9 @@
 #include "luhn.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 //Luhn exercise test case data version 1.6.0
 

--- a/exercises/practice/matching-brackets/CMakeLists.txt
+++ b/exercises/practice/matching-brackets/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/matching-brackets/matching_brackets_test.cpp
+++ b/exercises/practice/matching-brackets/matching_brackets_test.cpp
@@ -1,5 +1,9 @@
 #include "matching_brackets.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("paired_square_brackets")
 {

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -27,13 +27,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/meetup/meetup_test.cpp
+++ b/exercises/practice/meetup/meetup_test.cpp
@@ -1,6 +1,10 @@
 #include "meetup.h"
 #include <boost/date_time/gregorian/gregorian.hpp>
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 // This problem requires you to install and use the boost date_time library.
 // CMake will try to find and configure it for you if it is installed on your

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/nth-prime/nth_prime_test.cpp
+++ b/exercises/practice/nth-prime/nth_prime_test.cpp
@@ -1,5 +1,9 @@
 #include "nth_prime.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <stdexcept>
 
 TEST_CASE("first")

--- a/exercises/practice/nucleotide-count/CMakeLists.txt
+++ b/exercises/practice/nucleotide-count/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -1,5 +1,9 @@
 #include "nucleotide_count.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <map>
 #include <stdexcept>
 

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/pangram/pangram_test.cpp
+++ b/exercises/practice/pangram/pangram_test.cpp
@@ -1,5 +1,9 @@
 #include "pangram.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("sentence_empty")
 {

--- a/exercises/practice/pascals-triangle/CMakeLists.txt
+++ b/exercises/practice/pascals-triangle/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/pascals-triangle/pascals_triangle_test.cpp
+++ b/exercises/practice/pascals-triangle/pascals_triangle_test.cpp
@@ -1,5 +1,9 @@
 #include "pascals_triangle.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("zero_rows")
 {

--- a/exercises/practice/phone-number/CMakeLists.txt
+++ b/exercises/practice/phone-number/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/phone-number/phone_number_test.cpp
+++ b/exercises/practice/phone-number/phone_number_test.cpp
@@ -1,6 +1,10 @@
 #include "phone_number.h"
 
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <exception>
 
 TEST_CASE("cleans_the_number") {

--- a/exercises/practice/prime-factors/CMakeLists.txt
+++ b/exercises/practice/prime-factors/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/prime-factors/prime_factors_test.cpp
+++ b/exercises/practice/prime-factors/prime_factors_test.cpp
@@ -1,5 +1,9 @@
 #include "prime_factors.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("_1_yields_empty")
 {

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/protein-translation/protein_translation_test.cpp
+++ b/exercises/practice/protein-translation/protein_translation_test.cpp
@@ -1,4 +1,8 @@
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include "protein_translation.h"
 #include <vector>
 #include <string>

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/queen-attack/queen_attack_test.cpp
+++ b/exercises/practice/queen-attack/queen_attack_test.cpp
@@ -1,5 +1,9 @@
 #include "queen_attack.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("queens_in_default_positions")
 {

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/raindrops/raindrops_test.cpp
+++ b/exercises/practice/raindrops/raindrops_test.cpp
@@ -1,5 +1,9 @@
 #include "raindrops.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("one_yields_itself")
 {

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/reverse-string/reverse_string_test.cpp
+++ b/exercises/practice/reverse-string/reverse_string_test.cpp
@@ -1,5 +1,9 @@
 #include "reverse_string.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("an_empty_string")
 {

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/rna-transcription/rna_transcription_test.cpp
+++ b/exercises/practice/rna-transcription/rna_transcription_test.cpp
@@ -1,5 +1,9 @@
 #include "rna_transcription.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("transcribes_cytidine_to_guanosine")
 {

--- a/exercises/practice/robot-name/CMakeLists.txt
+++ b/exercises/practice/robot-name/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/robot-name/robot_name_test.cpp
+++ b/exercises/practice/robot-name/robot_name_test.cpp
@@ -1,5 +1,9 @@
 #include "robot_name.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <cctype>
 #include <string>
 #include <unordered_set>

--- a/exercises/practice/robot-simulator/CMakeLists.txt
+++ b/exercises/practice/robot-simulator/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/robot-simulator/robot_simulator_test.cpp
+++ b/exercises/practice/robot-simulator/robot_simulator_test.cpp
@@ -1,4 +1,8 @@
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include "robot_simulator.h"
 
 using robot_simulator::Robot;

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals_test.cpp
@@ -1,5 +1,9 @@
 #include "roman_numerals.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("one_yields_I")
 {

--- a/exercises/practice/say/CMakeLists.txt
+++ b/exercises/practice/say/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/say/say_test.cpp
+++ b/exercises/practice/say/say_test.cpp
@@ -1,5 +1,9 @@
 #include "say.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("zero")
 {

--- a/exercises/practice/scrabble-score/CMakeLists.txt
+++ b/exercises/practice/scrabble-score/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/scrabble-score/scrabble_score_test.cpp
+++ b/exercises/practice/scrabble-score/scrabble_score_test.cpp
@@ -1,5 +1,9 @@
 #include "scrabble_score.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("scores_an_empty_word_as_zero")
 {

--- a/exercises/practice/secret-handshake/CMakeLists.txt
+++ b/exercises/practice/secret-handshake/CMakeLists.txt
@@ -2,7 +2,7 @@
 get_filename_component(exercise ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 # Basic CMake project
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Name the project after the exercise
 project(${exercise} CXX)
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/secret-handshake/secret_handshake_test.cpp
+++ b/exercises/practice/secret-handshake/secret_handshake_test.cpp
@@ -1,4 +1,8 @@
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include "secret_handshake.h"
 #include <vector>
 #include <string>

--- a/exercises/practice/series/CMakeLists.txt
+++ b/exercises/practice/series/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/series/series_test.cpp
+++ b/exercises/practice/series/series_test.cpp
@@ -1,5 +1,9 @@
 #include "series.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <stdexcept>
 
 using namespace std;

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/sieve/sieve_test.cpp
+++ b/exercises/practice/sieve/sieve_test.cpp
@@ -1,5 +1,9 @@
 #include "sieve.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("no_primes_under_two")
 {

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/space-age/space_age_test.cpp
+++ b/exercises/practice/space-age/space_age_test.cpp
@@ -1,5 +1,9 @@
 #include "space_age.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("age_in_seconds")
 {

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/sum-of-multiples/sum_of_multiples_test.cpp
+++ b/exercises/practice/sum-of-multiples/sum_of_multiples_test.cpp
@@ -1,5 +1,9 @@
 #include "sum_of_multiples.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("sum_to_1_yields_0")
 {

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/triangle/triangle_test.cpp
+++ b/exercises/practice/triangle/triangle_test.cpp
@@ -1,5 +1,9 @@
 #include "triangle.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <stdexcept>
 
 TEST_CASE("equilateral_triangles_have_equal_sides")

--- a/exercises/practice/trinary/CMakeLists.txt
+++ b/exercises/practice/trinary/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/trinary/trinary_test.cpp
+++ b/exercises/practice/trinary/trinary_test.cpp
@@ -1,5 +1,9 @@
 #include "trinary.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 
 TEST_CASE("_1_yields_decimal_1")
 {

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/two-fer/two_fer_test.cpp
+++ b/exercises/practice/two-fer/two_fer_test.cpp
@@ -1,5 +1,9 @@
 #include "two_fer.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <string>
 
 // two-fer exercise test case data version 1.2.0

--- a/exercises/practice/word-count/CMakeLists.txt
+++ b/exercises/practice/word-count/CMakeLists.txt
@@ -21,13 +21,22 @@ endif()
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+elseif(EXERCISM_TEST_SUITE)
+    # The Exercism test suite is being run, the Docker image already
+    # includes a pre-built version of Catch.
+    find_package(Catch2 REQUIRED)
+    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
+    # When Catch is installed system wide we need to include a different
+    # header, we need this define to use the correct one.
+    target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
     add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES
-    CXX_STANDARD 14
+    CXX_STANDARD 17
     CXX_STANDARD_REQUIRED OFF
     CXX_EXTENSIONS OFF
 )

--- a/exercises/practice/word-count/word_count_test.cpp
+++ b/exercises/practice/word-count/word_count_test.cpp
@@ -1,5 +1,9 @@
 #include "word_count.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
 #include "test/catch.hpp"
+#endif
 #include <map>
 
 using namespace std;


### PR DESCRIPTION
Following exercism/cpp-test-runner#17 I changed all exercises `*_test.cpp` file and `CMakeLists.txt` so they can be run using a precompiled version of Catch2.

@ErikSchierboom how do I verify that this actually works in a prod-like environment?