### PR TITLE
Fix example solution lists

### DIFF
--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -10,7 +10,6 @@
       "binary_search_tree_test.cpp"
     ],
     "example": [
-      "example.cpp",
       "example.h"
     ]
   },

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -10,7 +10,6 @@
       "circular_buffer_test.cpp"
     ],
     "example": [
-      "example.cpp",
       "example.h"
     ]
   },

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -11,7 +11,7 @@
     ],
     "example": [
       "example.cpp",
-      "example.h"
+      "hello_world.h"
     ]
   },
   "source": "This is an exercise to introduce users to using Exercism",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -10,7 +10,6 @@
       "leap_test.cpp"
     ],
     "example": [
-      "example.cpp",
       "example.h"
     ]
   },

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -10,7 +10,6 @@
       "meetup_test.cpp"
     ],
     "example": [
-      "example.cpp",
       "example.h"
     ]
   },

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -10,7 +10,6 @@
       "two_fer_test.cpp"
     ],
     "example": [
-      "example.cpp",
       "example.h"
     ]
   },


### PR DESCRIPTION
Closes #458

* Removes unused example.cpp files from the files array. Those exercises only use an `example.h` file for the example solution.
* Sets the header file for `hello-world` to the `hello_world.h` file, which is reused without modification for both the example solution and the skeleton for the students.
