### PR TITLE
Include hello_world.h as part of the solution

### DIFF
--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -12,7 +12,8 @@
   ],
   "files": {
     "solution": [
-      "hello_world.cpp"
+      "hello_world.cpp",
+      "hello_world.h"
     ],
     "test": [
       "hello_world_test.cpp"


### PR DESCRIPTION
Fixes #482 

The skeleton solution downloaded for the user needs to include hello_world.h, otherwise the student needs to create that file themselves.

As a sidenote, does anyone know if there is any documentation on what the fields in this json file actually do? I haven't been able to find any and am only assuming from context.