### PR TITLE
Modified CMakeLists to add flags and fixed code flagging warnings.

### DIFF
--- a/exercises/practice/acronym/.meta/example.cpp
+++ b/exercises/practice/acronym/.meta/example.cpp
@@ -15,7 +15,7 @@ string acronym(string const &input_str) {
             delimiter_state = FOUND;
         } else if (delimiter_state == FOUND) {
             delimiter_state = NOT_FOUND;
-            acronym_str.push_back(std::toupper(c));
+            acronym_str.push_back(static_cast<char>(std::toupper(c)));
         }
     }
     return acronym_str;

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/all-your-base/CMakeLists.txt
+++ b/exercises/practice/all-your-base/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/anagram/.meta/example.cpp
+++ b/exercises/practice/anagram/.meta/example.cpp
@@ -11,7 +11,7 @@ string to_lower_copy(string const& s)
 {
     string cpy(s);
     for (auto& c: cpy) {
-        c = tolower(c);
+        c = static_cast<char>(tolower(c));
     }
     return cpy;
 }

--- a/exercises/practice/anagram/CMakeLists.txt
+++ b/exercises/practice/anagram/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/armstrong-numbers/.meta/example.cpp
+++ b/exercises/practice/armstrong-numbers/.meta/example.cpp
@@ -4,11 +4,11 @@
 
 bool armstrong_numbers::is_armstrong_number(int number) {
     int length = number != 0 && number != 1
-                     ? std::log10(std::abs(static_cast<double>(number))) + 1
+                     ? static_cast<int>(std::log10(std::abs(static_cast<double>(number))) + 1)
                      : 1;
     int accumulate = 0;
     for (int current = number; current != 0; current /= 10) {
-        accumulate += std::pow(current % 10, length);
+        accumulate += static_cast<int>(std::pow(current % 10, length));
     }
     return accumulate == number;
 }

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/atbash-cipher/.meta/example.cpp
+++ b/exercises/practice/atbash-cipher/.meta/example.cpp
@@ -10,7 +10,7 @@ const char ALPHA_END = 'z';
 
 char atbash_transform(char c)
 {
-    return static_cast<char>(std::isalpha(c)) ? ALPHA_END - static_cast<char>(std::tolower(c)) + ALPHA_START : c;
+    return static_cast<char>(std::isalpha(c) ? ALPHA_END - std::tolower(c) + ALPHA_START : c);
 }
 
 std::string encode(std::string const& plaintext)

--- a/exercises/practice/atbash-cipher/.meta/example.cpp
+++ b/exercises/practice/atbash-cipher/.meta/example.cpp
@@ -10,7 +10,7 @@ const char ALPHA_END = 'z';
 
 char atbash_transform(char c)
 {
-    return std::isalpha(c) ? ALPHA_END - std::tolower(c) + ALPHA_START : c;
+    return static_cast<char>(std::isalpha(c)) ? ALPHA_END - static_cast<char>(std::tolower(c)) + ALPHA_START : c;
 }
 
 std::string encode(std::string const& plaintext)

--- a/exercises/practice/atbash-cipher/CMakeLists.txt
+++ b/exercises/practice/atbash-cipher/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/beer-song/CMakeLists.txt
+++ b/exercises/practice/beer-song/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/binary-search-tree/CMakeLists.txt
+++ b/exercises/practice/binary-search-tree/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/binary-search/CMakeLists.txt
+++ b/exercises/practice/binary-search/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/binary/CMakeLists.txt
+++ b/exercises/practice/binary/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/circular-buffer/CMakeLists.txt
+++ b/exercises/practice/circular-buffer/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/clock/CMakeLists.txt
+++ b/exercises/practice/clock/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/complex-numbers/CMakeLists.txt
+++ b/exercises/practice/complex-numbers/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/crypto-square/.meta/example.cpp
+++ b/exercises/practice/crypto-square/.meta/example.cpp
@@ -12,7 +12,7 @@ string to_lower_copy(string const& s)
 {
     string cpy(s);
     for (auto& c: cpy) {
-        c = tolower(c);
+        c = static_cast<char>(tolower(c));
     }
     return cpy;
 }

--- a/exercises/practice/crypto-square/CMakeLists.txt
+++ b/exercises/practice/crypto-square/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/etl/.meta/example.cpp
+++ b/exercises/practice/etl/.meta/example.cpp
@@ -11,7 +11,7 @@ map<char, int> transform(map<int, vector<char>> const& old)
     map<char, int> result;
     for (auto const& item : old) {
         for (char c : item.second) {
-            result[tolower(c)] = item.first;
+            result[static_cast<char>(tolower(c))] = item.first;
         }
     }
     return result;

--- a/exercises/practice/etl/CMakeLists.txt
+++ b/exercises/practice/etl/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/food-chain/CMakeLists.txt
+++ b/exercises/practice/food-chain/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -53,6 +53,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # We need boost libraries

--- a/exercises/practice/grade-school/CMakeLists.txt
+++ b/exercises/practice/grade-school/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/hexadecimal/.meta/example.cpp
+++ b/exercises/practice/hexadecimal/.meta/example.cpp
@@ -12,7 +12,7 @@ int convert(const std::string &text)
         if (c >= '0' && c <= '9') {
             result += c - '0';
         } else {
-            c = std::tolower(c);
+            c = static_cast<char>(std::tolower(c));
             if (c >= 'a' && c <= 'f') {
                 result += 10 + c - 'a';
             } else {

--- a/exercises/practice/hexadecimal/CMakeLists.txt
+++ b/exercises/practice/hexadecimal/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/isogram/.meta/example.cpp
+++ b/exercises/practice/isogram/.meta/example.cpp
@@ -11,7 +11,7 @@ bool is_isogram(std::string const& input_str)
     {
         if (isalnum(ch))
         {
-            auto ret = chars.insert(tolower(ch));
+            auto ret = chars.insert(static_cast<char>(tolower(ch)));
             if (ret.second == false)
             {
                 return false;

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/matching-brackets/CMakeLists.txt
+++ b/exercises/practice/matching-brackets/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/meetup/.meta/example.h
+++ b/exercises/practice/meetup/.meta/example.h
@@ -192,19 +192,19 @@ public:
 private:
     boost::gregorian::date teenth_day(boost::date_time::weekdays day) const
     {
-        return boost::gregorian::first_day_of_the_week_after(day).get_date({year_, month_, 12});
+        return boost::gregorian::first_day_of_the_week_after(static_cast<unsigned short>(day)).get_date({year_, month_, 12});
     }
 
     boost::gregorian::date first_weekday(boost::date_time::weekdays day) const
     {
-        return boost::gregorian::first_day_of_the_week_in_month(day, month_).get_date(year_);
+        return boost::gregorian::first_day_of_the_week_in_month(static_cast<unsigned short>(day), month_).get_date(year_);
     }
 
     boost::gregorian::date nth_weekday(
         boost::gregorian::nth_day_of_the_week_in_month::week_num n,
         boost::date_time::weekdays day) const
     {
-        return boost::gregorian::nth_day_of_the_week_in_month(n, day, month_).get_date(year_);
+        return boost::gregorian::nth_day_of_the_week_in_month(n, static_cast<unsigned short>(day), month_).get_date(year_);
     }
 
     boost::gregorian::date second_weekday(boost::date_time::weekdays day) const
@@ -224,7 +224,7 @@ private:
 
     boost::gregorian::date last_weekday(boost::date_time::weekdays day) const
     {
-        return boost::gregorian::last_day_of_the_week_in_month(day, month_).get_date(year_);
+        return boost::gregorian::last_day_of_the_week_in_month(static_cast<unsigned short>(day), month_).get_date(year_);
     }
 
     const boost::gregorian::date::year_type year_;

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -53,6 +53,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # We need boost libraries

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/nucleotide-count/CMakeLists.txt
+++ b/exercises/practice/nucleotide-count/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/pascals-triangle/.meta/example.cpp
+++ b/exercises/practice/pascals-triangle/.meta/example.cpp
@@ -16,7 +16,7 @@ std::vector<std::vector<int>> generate_rows(size_t n)
         for (size_t k = 0; k <= i; k++)
         {
             rowNum.push_back(val);
-            val = val * (i - k) / (k + 1);
+            val = static_cast<int>(val * (i - k) / (k + 1));
         }
 
         res.push_back(rowNum);

--- a/exercises/practice/pascals-triangle/CMakeLists.txt
+++ b/exercises/practice/pascals-triangle/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/phone-number/CMakeLists.txt
+++ b/exercises/practice/phone-number/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/prime-factors/CMakeLists.txt
+++ b/exercises/practice/prime-factors/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/robot-name/CMakeLists.txt
+++ b/exercises/practice/robot-name/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/robot-simulator/CMakeLists.txt
+++ b/exercises/practice/robot-simulator/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/say/CMakeLists.txt
+++ b/exercises/practice/say/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/say/say_test.cpp
+++ b/exercises/practice/say/say_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE("a_really_big_number")
 
 TEST_CASE("raises_an_error_below_zero")
 {
-    REQUIRE_THROWS_AS(say::in_english(-1), std::domain_error);
+    REQUIRE_THROWS_AS(say::in_english(static_cast<unsigned long long>(-1)), std::domain_error);
 }
 
 TEST_CASE("raises_an_error_for_one_trillion")

--- a/exercises/practice/scrabble-score/CMakeLists.txt
+++ b/exercises/practice/scrabble-score/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/secret-handshake/CMakeLists.txt
+++ b/exercises/practice/secret-handshake/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/series/CMakeLists.txt
+++ b/exercises/practice/series/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/trinary/CMakeLists.txt
+++ b/exercises/practice/trinary/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?

--- a/exercises/practice/word-count/.meta/example.cpp
+++ b/exercises/practice/word-count/.meta/example.cpp
@@ -43,7 +43,7 @@ string normalize_text(string const& text)
 {
     string normalized;
     transform(text.begin(), text.end(), back_inserter(normalized),
-        [](const char c) { return (isalnum(c) || c == '\'') ? tolower(c) : ' '; });
+        [](const char c) { return (static_cast<char>(isalnum(c)) || c == '\'') ? static_cast<char>(tolower(c)) : ' '; });
     return normalized;
 }
 

--- a/exercises/practice/word-count/CMakeLists.txt
+++ b/exercises/practice/word-count/CMakeLists.txt
@@ -47,6 +47,10 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
         COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
     )
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC") 
+    set_target_properties(${exercise} PROPERTIES
+        COMPILE_FLAGS "/W4 /WX"
+    )
 endif()
 
 # Configure to run all the tests?


### PR DESCRIPTION
Hopefully fixes #302 

For all of the exercise CMakeLists.txt I've added ``/W4`` (Level 4 warnings) and ``/WX`` (Warnings as errors). I've also gone through and fixed code which currently fails due to this addition. I've tested these changes in both VS2019 and VS2022 toolsets.

Note: currently don't have a working gcc/clang setup so will await CI to check the changes.

As per the thread, I didn't add ``/Wall`` as I believe this is somewhat heavy-handed for what is the desired outcome. I was toying with suggesting ``/permissive-`` however I kept strictly to the main point of the issue.

Warning Levels: https://docs.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-160
WX Flag: https://docs.microsoft.com/en-us/cpp/build/reference/wx-treat-linker-warnings-as-errors?view=msvc-160