### PR TITLE
Bump the Linux Min config version to Ubuntu 18.04.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linux-min:
     name: Linux Min Config
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         compiler: [clang++-3.8, g++-5]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: [clang++-3.8, g++-5]
+        compiler: [clang++-6.0, g++-7]
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Install Dependencies
       # Boost must be installed only because the CMake version (3.12) can't
       # detect the installed Boost version (1.69)
-      run: sudo apt-get update && sudo apt-get -y install ninja-build libboost-date-time-dev clang-3.8 g++-5 g++-multilib
+      run: sudo apt-get update && sudo apt-get -y install ninja-build libboost-date-time-dev clang-6.0 g++-7 g++-multilib
     - name: Run tests with common Catch
       run: |
         cmake -G Ninja .

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -22,7 +22,7 @@ the IDE.
 This language track requires a compiler with [C++14](http://en.wikipedia.org/wiki/C%2B%2B14)
 support, which was released in 2014. All major compilers released in the last few years should
 be compatible, so as long as you are on a fairly recent version you should be fine.
-Specifically, GCC version 5 or later, Clang version 3.8 or later, or Visual
+Specifically, GCC version 7 or later, Clang version 6 or later, or Visual
 Studio 2017 or later.
 
 ### CMake

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -68,7 +68,7 @@ You should be able to use other integrated IDE's such as JetBrains' CLion in a s
 
 All recent Linux distribution releases have compatible C++14 compilers, you
 should be able to install it using your package manager. The versions we support
-are the default installed versions in Ubuntu LTS 16.04.
+are the default installed versions in Ubuntu LTS 18.04.
 
 For example, on Ubuntu you would use the following command to install gcc.
 


### PR DESCRIPTION
Closes #487 

Github Actions has already dropped support for Ubuntu 16.04. Our CI will not work without bumping the min version.

This just bumps the Min version to 18.04 without updating anything else, so that we can continue to test on our minimum supported version.