### PR TITLE
Fix compile error for exercises using boost:date_time lib

### DIFF
--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.5.1)
 project(${exercise} CXX)
 
 # Locate Boost date_time library
-set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.58 REQUIRED COMPONENTS date_time)

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -8,7 +8,6 @@ cmake_minimum_required(VERSION 3.5.1)
 project(${exercise} CXX)
 
 # Locate Boost date_time library
-set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost 1.58 REQUIRED COMPONENTS date_time)


### PR DESCRIPTION
## Overview

This PR is following up on [cpp: gigasecond does not compile](https://github.com/exercism/cpp-test-runner/issues/37) and [a fix for cpp-test-runner](https://github.com/exercism/cpp-test-runner/pull/38) which updated the test runner dockerfile to add a missing `boost::date_time` lib used in "gigasecond" and "meetup" CPP exercises.

[PR 38](https://github.com/exercism/cpp-test-runner/pull/38) did the following:

- install boost in test runner docker container
- add minimal tests for the test runner ensuring the library can be used by the runner

Unfortunately, this didn't fix the problem completely because the existing two exercises that use `boost::date_time`  require the static versions of boost in their `CMakeLists.txt` files.

Also related is #491.

## Proposed solution

This pull request updates those two exercises by removing the static lib requirement and I expect this will resolve the problem.