### PR TITLE
Split out example from hello_world.h

### DIFF
--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -20,7 +20,7 @@
     ],
     "example": [
       ".meta/example.cpp",
-      "hello_world.h"
+      ".meta/example.h"
     ]
   },
   "source": "This is an exercise to introduce users to using Exercism",

--- a/exercises/practice/hello-world/.meta/example.h
+++ b/exercises/practice/hello-world/.meta/example.h
@@ -1,0 +1,22 @@
+// This is an include guard.
+// You could alternatively use '#pragma once'
+// See https://en.wikipedia.org/wiki/Include_guard
+#if !defined(HELLO_WORLD_H)
+#define HELLO_WORLD_H
+
+// Include the string header so that we have access to 'std::string'
+#include <string>
+
+// Declare a namespace for the function(s) we are exporting.
+// https://en.cppreference.com/w/cpp/language/namespace
+namespace hello_world {
+
+// Declare the 'hello()' function, which takes no arguments and returns a
+// 'std::string'. The function itself is defined in the hello_world.cpp source
+// file. Because it is inside of the 'hello_world' namespace, it's full name is
+// 'hello_world::hello()'.
+std::string hello();
+
+}  // namespace hello_world
+
+#endif


### PR DESCRIPTION
Listing the `hello_world.h` file as an example file causes it to not be downloaded. This creates a copy of that file in the `.meta` directory to use as the example solution.

Fixes #482

See #484 for a previous attempt to fix issue #482, and discussion from @iHiD and @ErikSchierboom helping to diagnose the problem :)