### PR TITLE
Fixing error in instructions.md examples (remove `and` from examples)

### DIFF
--- a/exercises/practice/say/.docs/instructions.md
+++ b/exercises/practice/say/.docs/instructions.md
@@ -58,6 +58,6 @@ Use _and_ (correctly) when spelling out the number in English:
 
 - 14 becomes "fourteen".
 - 100 becomes "one hundred".
-- 120 becomes "one hundred and twenty".
-- 1002 becomes "one thousand and two".
-- 1323 becomes "one thousand three hundred and twenty-three".
+- 120 becomes "one hundred twenty".
+- 1002 becomes "one thousand two".
+- 1323 becomes "one thousand three hundred twenty-three".


### PR DESCRIPTION
This PR fixes a typo in the examples in the instructions.

The instructions have examples that include the string `"and"` in the output for numbers like `120` (output stated in instructions: `"one hundred and twenty"`). However, the actual test cases in the code don't include the word `"and"` for numbers like `120`, and instead use output like `"one hundred twenty"` (for example, the test case for `123` in the code uses the output `"one hundred twenty-three"`; `"and"` is not present in the output).

This PR removes the `"and"` from the instructions' examples to make their syntax correct.

Let me know if I missed anything. Thanks :slightly_smiling_face: 