### PR TITLE
Updated Link to general contribution guides #503

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Exercism Exercises in C++
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md)
+Please see the [contributing guides](https://github.com/exercism/docs/tree/main/building/github)
 
 The most useful way to start contributing to this track is to review Pull Requests and/or some of the open track issues.
 There are not many active contributors, so anyone reviewing PRs or Issues, even just to +1 someone elses opinion, is appreciated.


### PR DESCRIPTION
As mentioned in #503 the Link to the Contribution Guide does not work anymore. As i was unable to find the file the Link was pointing to, i just let it point to the `docs/building/github` folder inside the `Exercism/docs` repository