### PR TITLE
feature: added test case to acronym exercise to cover missed case

### DIFF
--- a/exercises/practice/acronym/acronym_test.cpp
+++ b/exercises/practice/acronym/acronym_test.cpp
@@ -62,4 +62,13 @@ TEST_CASE("hyphenated")
     REQUIRE(expected == actual);
 }
 
+TEST_CASE("all_lowercase")
+{
+    const string actual = acronym::acronym("you only live once");
+
+    const string expected{"YOLO"};
+
+    REQUIRE(expected == actual);
+}
+
 #endif


### PR DESCRIPTION
The current iteration of the acronym exercise missed the case where the first letter of the phrase is lowercase.

I had a mentee start their solution with 
```cpp
std::string result(1, input[0]);
```
and all tests passed.

My new test accounts for this situation.