### PR TITLE
Update Boost documentation links.

### DIFF
--- a/exercises/practice/gigasecond/gigasecond_test.cpp
+++ b/exercises/practice/gigasecond/gigasecond_test.cpp
@@ -9,7 +9,7 @@
 // This problem requires you to install and use the boost date_time library.
 // CMake will try to find and configure it for you if it is installed on your
 // system.
-// See <http://www.boost.org/doc/libs/1_58_0/doc/html/date_time/posix_time.html>
+// See <http://www.boost.org/doc/libs/1_74_0/doc/html/date_time/posix_time.html>
 // for documentation on boost::posix_time
 
 using namespace boost::posix_time;

--- a/exercises/practice/meetup/meetup_test.cpp
+++ b/exercises/practice/meetup/meetup_test.cpp
@@ -9,7 +9,7 @@
 // This problem requires you to install and use the boost date_time library.
 // CMake will try to find and configure it for you if it is installed on your
 // system.
-// See <http://www.boost.org/doc/libs/1_58_0/doc/html/date_time.html> for
+// See <http://www.boost.org/doc/libs/1_74_0/doc/html/date_time.html> for
 // documentation on boost::gregorian::date
 
 TEST_CASE("monteenth_of_May_2013")


### PR DESCRIPTION
Updates the documentation links in the boost test files to point to the most recent version of boost.

The real goal of this is to touch the test files so that the problems are updated for users on the website, so that this will fix the problem of building Boost in the Web UI for people who started the exercise before #495. Once merged, students in the bad state should have their exercises updated mostly automatically in the Web editor.

See https://github.com/exercism/exercism/issues/6332 for the reasoning

Closes #491
Closes #500 
Closes #514

