### PR TITLE
Add tests for valid queen positions

### DIFF
--- a/exercises/practice/queen-attack/queen_attack_test.cpp
+++ b/exercises/practice/queen-attack/queen_attack_test.cpp
@@ -34,6 +34,20 @@ TEST_CASE("queen_positions_must_be_distinct")
     REQUIRE_THROWS_AS((queen_attack::chess_board{pos, pos}), std::domain_error);
 }
 
+TEST_CASE("queen_positions_must_have_valid_row")
+{
+    const auto white = std::make_pair(-3, 7);
+    const auto black = std::make_pair(6, 1);
+    REQUIRE_THROWS_AS((queen_attack::chess_board{white, black}), std::domain_error);
+}
+
+TEST_CASE("queen_positions_must_have_valid_column")
+{
+    const auto white = std::make_pair(3, 7);
+    const auto black = std::make_pair(6, 8);
+    REQUIRE_THROWS_AS((queen_attack::chess_board{white, black}), std::domain_error);
+}
+
 TEST_CASE("string_representation")
 {
     const queen_attack::chess_board board{std::make_pair(2, 4), std::make_pair(6, 6)};


### PR DESCRIPTION
The tests for the C++ version of this exercise do not follow the problem specification and don't validate that the position is within [0, 8).

This PR adds two tests, one verifying the row with a value < 0 and one verifying the column with a value > 7.