### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -190,7 +190,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "2fbd008c-5007-4403-ae71-f4d1f5ccaf8f",
         "practices": [],
         "prerequisites": [],
@@ -213,7 +213,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "46cb230c-8ce9-431d-9dea-a195a3abd117",
         "practices": [],
         "prerequisites": [],
@@ -322,7 +322,7 @@
       },
       {
         "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
+        "name": "Sum of Multiples",
         "uuid": "a190ad11-db1c-4624-a477-e1d0c91d8b4f",
         "practices": [],
         "prerequisites": [],
@@ -546,7 +546,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "0dd45f6a-c6cd-4549-a56b-7babe0a71add",
         "practices": [],
         "prerequisites": [],
@@ -670,7 +670,7 @@
       },
       {
         "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
+        "name": "Pascal's Triangle",
         "uuid": "7ed4434a-3564-4194-b91a-d3baeec9c519",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579