### PR TITLE
Sync roman-numerals with problem-specifications

### DIFF
--- a/exercises/practice/roman-numerals/.docs/instructions.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.md
@@ -2,17 +2,15 @@
 
 Write a function to convert from normal numbers to Roman Numerals.
 
-The Romans were a clever bunch. They conquered most of Europe and ruled
-it for hundreds of years. They invented concrete and straight roads and
-even bikinis. One thing they never discovered though was the number
-zero. This made writing and dating extensive histories of their exploits
-slightly more challenging, but the system of numbers they came up with
-is still in use today. For example the BBC uses Roman numerals to date
-their programmes.
+The Romans were a clever bunch.
+They conquered most of Europe and ruled it for hundreds of years.
+They invented concrete and straight roads and even bikinis.
+One thing they never discovered though was the number zero.
+This made writing and dating extensive histories of their exploits slightly more challenging, but the system of numbers they came up with is still in use today.
+For example the BBC uses Roman numerals to date their programs.
 
-The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
-these letters have lots of straight lines and are hence easy to hack
-into stone tablets).
+The Romans wrote numbers using letters - I, V, X, L, C, D, M.
+(notice these letters have lots of straight lines and are hence easy to hack into stone tablets).
 
 ```text
  1  => I
@@ -20,12 +18,10 @@ into stone tablets).
  7  => VII
 ```
 
-There is no need to be able to convert numbers larger than about 3000.
+The maximum number supported by this notation is 3,999.
 (The Romans themselves didn't tend to go any higher)
 
-Wikipedia says: Modern Roman numerals ... are written by expressing each
-digit separately starting with the left most digit and skipping any
-digit with a value of zero.
+Wikipedia says: Modern Roman numerals ... are written by expressing each digit separately starting with the left most digit and skipping any digit with a value of zero.
 
 To see this in practice, consider the example of 1990.
 
@@ -40,4 +36,6 @@ In Roman numerals 1990 is MCMXC:
 2000=MM
 8=VIII
 
-See also: http://www.novaroma.org/via_romana/numbers.html
+Learn more about [Roman numberals on Wikipedia][roman-numerals].
+
+[roman-numerals]: https://wiki.imperivm-romanvm.com/wiki/Roman_Numerals

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [
     "LegalizeAdulthood"
   ],
@@ -24,6 +23,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "source": "The Roman Numeral Kata",
-  "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"
+  "source_url": "https://codingdojo.org/kata/RomanNumerals/"
 }

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,57 +1,88 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
-description = "1 is a single I"
+description = "1 is I"
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
-description = "2 is two I's"
+description = "2 is II"
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
-description = "3 is three I's"
+description = "3 is III"
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
-description = "4, being 5 - 1, is IV"
+description = "4 is IV"
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
-description = "5 is a single V"
+description = "5 is V"
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
-description = "6, being 5 + 1, is VI"
+description = "6 is VI"
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
-description = "9, being 10 - 1, is IX"
+description = "9 is IX"
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
-description = "20 is two X's"
+description = "27 is XXVII"
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
-description = "48 is not 50 - 2 but rather 40 + 8"
+description = "48 is XLVIII"
+
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is XLIX"
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
-description = "50 is a single L"
+description = "59 is LIX"
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
-description = "90, being 100 - 10, is XC"
+description = "93 is XCIII"
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
-description = "100 is a single C"
+description = "141 is CXLI"
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
-description = "60, being 50 + 10, is LX"
+description = "163 is CLXIII"
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
-description = "400, being 500 - 100, is CD"
+description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
-description = "500 is a single D"
+description = "575 is DLXXV"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
-description = "900, being 1000 - 100, is CM"
+description = "911 is CMXI"
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
-description = "1000 is a single M"
+description = "1024 is MXXIV"
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is three M's"
+description = "3000 is MMM"
+
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
+
+[efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
+description = "1666 is MDCLXVI"
+
+[3bc4b41c-c2e6-49d9-9142-420691504336]
+description = "3001 is MMMI"
+
+[4e18e96b-5fbb-43df-a91b-9cb511fe0856]
+description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -29,9 +29,6 @@ description = "20 is two X's"
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
 description = "48 is not 50 - 2 but rather 40 + 8"
 
-[607ead62-23d6-4c11-a396-ef821e2e5f75]
-description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
-
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "50 is a single L"
 

--- a/exercises/practice/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals_test.cpp
@@ -42,6 +42,10 @@ TEST_CASE("48_is_xlviii")
 {
     REQUIRE("XLVIII" == roman_numerals::convert(48));
 }
+TEST_CASE("49_is_xlix")
+{
+    REQUIRE("XLIX" == roman_numerals::convert(49));
+}
 TEST_CASE("59_is_lix")
 {
     REQUIRE("LIX" == roman_numerals::convert(59));
@@ -77,5 +81,33 @@ TEST_CASE("1024_is_mxxiv")
 TEST_CASE("3000_is_mmm")
 {
     REQUIRE("MMM" == roman_numerals::convert(3000));
+}
+TEST_CASE("16_is_xvi")
+{
+    REQUIRE("XVI" == roman_numerals::convert(16));
+}
+TEST_CASE("66_is_lxvi")
+{
+    REQUIRE("LXVI" == roman_numerals::convert(66));
+}
+TEST_CASE("166_is_clxvi")
+{
+    REQUIRE("CLXVI" == roman_numerals::convert(166));
+}
+TEST_CASE("666_is_dclxvi")
+{
+    REQUIRE("DCLXVI" == roman_numerals::convert(666));
+}
+TEST_CASE("1666_is_mdclxvi")
+{
+    REQUIRE("MDCLXVI" == roman_numerals::convert(1666));
+}
+TEST_CASE("3001_is_mmmi")
+{
+    REQUIRE("MMMI" == roman_numerals::convert(3001));
+}
+TEST_CASE("3999_is_mmmcmxcix")
+{
+    REQUIRE("MMMCMXCIX" == roman_numerals::convert(3999));
 }
 #endif

--- a/exercises/practice/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals_test.cpp
@@ -5,93 +5,76 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("one_yields_I")
+TEST_CASE("1_is_i")
 {
     REQUIRE("I" == roman_numerals::convert(1));
 }
-
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("two_yields_II")
+TEST_CASE("2_is_ii")
 {
     REQUIRE("II" == roman_numerals::convert(2));
 }
-
-TEST_CASE("three_yields_III")
+TEST_CASE("3_is_iii")
 {
     REQUIRE("III" == roman_numerals::convert(3));
 }
-
-TEST_CASE("four_yields_IV")
+TEST_CASE("4_is_iv")
 {
     REQUIRE("IV" == roman_numerals::convert(4));
 }
-
-TEST_CASE("five_yields_V")
+TEST_CASE("5_is_v")
 {
     REQUIRE("V" == roman_numerals::convert(5));
 }
-
-TEST_CASE("six_yields_VI")
+TEST_CASE("6_is_vi")
 {
     REQUIRE("VI" == roman_numerals::convert(6));
 }
-
-TEST_CASE("nine_yields_IX")
+TEST_CASE("9_is_ix")
 {
     REQUIRE("IX" == roman_numerals::convert(9));
 }
-
-TEST_CASE("twenty_seven_yields_XXVII")
+TEST_CASE("27_is_xxvii")
 {
     REQUIRE("XXVII" == roman_numerals::convert(27));
 }
-
-TEST_CASE("forty_eight_yields_XLVIII")
+TEST_CASE("48_is_xlviii")
 {
     REQUIRE("XLVIII" == roman_numerals::convert(48));
 }
-
-TEST_CASE("fifty_nine_yields_LIX")
+TEST_CASE("59_is_lix")
 {
     REQUIRE("LIX" == roman_numerals::convert(59));
 }
-
-TEST_CASE("ninety_three_yields_XCIII")
+TEST_CASE("93_is_xciii")
 {
     REQUIRE("XCIII" == roman_numerals::convert(93));
 }
-
-TEST_CASE("one_hundred_forty_one_yields_CXLI")
+TEST_CASE("141_is_cxli")
 {
     REQUIRE("CXLI" == roman_numerals::convert(141));
 }
-
-TEST_CASE("one_hundred_sixty_three_yields_CLXIII")
+TEST_CASE("163_is_clxiii")
 {
     REQUIRE("CLXIII" == roman_numerals::convert(163));
 }
-
-TEST_CASE("four_hundred_two_yields_CDII")
+TEST_CASE("402_is_cdii")
 {
     REQUIRE("CDII" == roman_numerals::convert(402));
 }
-
-TEST_CASE("five_hundred_seventy_five_yields_DLXXV")
+TEST_CASE("575_is_dlxxv")
 {
     REQUIRE("DLXXV" == roman_numerals::convert(575));
 }
-
-TEST_CASE("nine_hundred_eleven_yields_CMXI")
+TEST_CASE("911_is_cmxi")
 {
     REQUIRE("CMXI" == roman_numerals::convert(911));
 }
-
-TEST_CASE("one_thousand_twenty_four_yields_MXXIV")
+TEST_CASE("1024_is_mxxiv")
 {
     REQUIRE("MXXIV" == roman_numerals::convert(1024));
 }
-
-TEST_CASE("three_thousand_yields_MMM")
+TEST_CASE("3000_is_mmm")
 {
     REQUIRE("MMM" == roman_numerals::convert(3000));
 }


### PR DESCRIPTION

This brings the `roman-numerals` exercise up to date with the specification in problem-specifications.

For clarity, it does this in several steps.

1. Rectify tests.toml, removing unimplemented tests.
2. Normalize the test descriptions to match the canonical data.
3. Finally, sync with the upstream specification.
