### PR TITLE
Sync raindrops with problem-specifications

### DIFF
--- a/exercises/practice/raindrops/.docs/instructions.md
+++ b/exercises/practice/raindrops/.docs/instructions.md
@@ -1,6 +1,8 @@
 # Instructions
 
-Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors. A factor is a number that evenly divides into another number, leaving no remainder. The simplest way to test if a one number is a factor of another is to use the [modulo operation](https://en.wikipedia.org/wiki/Modulo_operation).
+Your task is to convert a number into a string that contains raindrop sounds corresponding to certain potential factors.
+A factor is a number that evenly divides into another number, leaving no remainder.
+The simplest way to test if one number is a factor of another is to use the [modulo operation][modulo].
 
 The rules of `raindrops` are that if a given number:
 
@@ -14,3 +16,5 @@ The rules of `raindrops` are that if a given number:
 - 28 has 7 as a factor, but not 3 or 5, so the result would be "Plong".
 - 30 has both 3 and 5 as factors, but not 7, so the result would be "PlingPlang".
 - 34 is not factored by 3, 5, or 7, so the result would be "34".
+
+[modulo]: https://en.wikipedia.org/wiki/Modulo_operation

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [
     "LegalizeAdulthood"
   ],
@@ -24,6 +23,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"
 }

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [1575d549-e502-46d4-a8e1-6b7bec6123d8]
 description = "the sound for 1 is 1"
@@ -16,6 +23,9 @@ description = "the sound for 7 is Plong"
 
 [6bb4947b-a724-430c-923f-f0dc3d62e56a]
 description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
 
 [0dd66175-e3e2-47fc-8750-d01739856671]
 description = "the sound for 9 is Pling as it has a factor 3"
@@ -35,6 +45,9 @@ description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
 [d2e75317-b72e-40ab-8a64-6734a21dece1]
 description = "the sound for 25 is Plang as it has a factor 5"
 
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
 [bdf061de-8564-4899-a843-14b48b722789]
 description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
 
@@ -46,3 +59,6 @@ description = "the sound for 52 is 52"
 
 [e46677ed-ff1a-419f-a740-5c713d2830e4]
 description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -17,9 +17,6 @@ description = "the sound for 7 is Plong"
 [6bb4947b-a724-430c-923f-f0dc3d62e56a]
 description = "the sound for 6 is Pling as it has a factor 3"
 
-[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
-description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
-
 [0dd66175-e3e2-47fc-8750-d01739856671]
 description = "the sound for 9 is Pling as it has a factor 3"
 
@@ -38,9 +35,6 @@ description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
 [d2e75317-b72e-40ab-8a64-6734a21dece1]
 description = "the sound for 25 is Plang as it has a factor 5"
 
-[a09c4c58-c662-4e32-97fe-f1501ef7125c]
-description = "the sound for 27 is Pling as it has a factor 3"
-
 [bdf061de-8564-4899-a843-14b48b722789]
 description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
 
@@ -52,6 +46,3 @@ description = "the sound for 52 is 52"
 
 [e46677ed-ff1a-419f-a740-5c713d2830e4]
 description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
-
-[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
-description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/raindrops/raindrops_test.cpp
+++ b/exercises/practice/raindrops/raindrops_test.cpp
@@ -26,6 +26,10 @@ TEST_CASE("the_sound_for_6_is_pling_as_it_has_a_factor_3")
 {
     REQUIRE("Pling" == raindrops::convert(6));
 }
+TEST_CASE("2_to_the_power_3_does_not_make_a_raindrop_sound_as_3_is_the_exponent_not_the_base")
+{
+    REQUIRE("8" == raindrops::convert(8));
+}
 TEST_CASE("the_sound_for_9_is_pling_as_it_has_a_factor_3")
 {
     REQUIRE("Pling" == raindrops::convert(9));
@@ -50,6 +54,10 @@ TEST_CASE("the_sound_for_25_is_plang_as_it_has_a_factor_5")
 {
     REQUIRE("Plang" == raindrops::convert(25));
 }
+TEST_CASE("the_sound_for_27_is_pling_as_it_has_a_factor_3")
+{
+    REQUIRE("Pling" == raindrops::convert(27));
+}
 TEST_CASE("the_sound_for_35_is_plangplong_as_it_has_factors_5_and_7")
 {
     REQUIRE("PlangPlong" == raindrops::convert(35));
@@ -65,5 +73,9 @@ TEST_CASE("the_sound_for_52_is_52")
 TEST_CASE("the_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7")
 {
     REQUIRE("PlingPlangPlong" == raindrops::convert(105));
+}
+TEST_CASE("the_sound_for_3125_is_plang_as_it_has_a_factor_5")
+{
+    REQUIRE("Plang" == raindrops::convert(3125));
 }
 #endif

--- a/exercises/practice/raindrops/raindrops_test.cpp
+++ b/exercises/practice/raindrops/raindrops_test.cpp
@@ -5,78 +5,64 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("one_yields_itself")
+TEST_CASE("the_sound_for_1_is_1")
 {
     REQUIRE("1" == raindrops::convert(1));
 }
-
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("three_yields_pling")
+TEST_CASE("the_sound_for_3_is_pling")
 {
     REQUIRE("Pling" == raindrops::convert(3));
 }
-
-TEST_CASE("five_yields_plang")
+TEST_CASE("the_sound_for_5_is_plang")
 {
     REQUIRE("Plang" == raindrops::convert(5));
 }
-
-TEST_CASE("seven_yields_plong")
+TEST_CASE("the_sound_for_7_is_plong")
 {
     REQUIRE("Plong" == raindrops::convert(7));
 }
-
-TEST_CASE("six_yields_pling")
+TEST_CASE("the_sound_for_6_is_pling_as_it_has_a_factor_3")
 {
     REQUIRE("Pling" == raindrops::convert(6));
 }
-
-TEST_CASE("nine_yields_pling")
+TEST_CASE("the_sound_for_9_is_pling_as_it_has_a_factor_3")
 {
     REQUIRE("Pling" == raindrops::convert(9));
 }
-
-TEST_CASE("ten_yields_plang")
+TEST_CASE("the_sound_for_10_is_plang_as_it_has_a_factor_5")
 {
     REQUIRE("Plang" == raindrops::convert(10));
 }
-
-TEST_CASE("fourteen_yields_plong")
+TEST_CASE("the_sound_for_14_is_plong_as_it_has_a_factor_of_7")
 {
     REQUIRE("Plong" == raindrops::convert(14));
 }
-
-TEST_CASE("fifteen_yields_plingplang")
+TEST_CASE("the_sound_for_15_is_plingplang_as_it_has_factors_3_and_5")
 {
     REQUIRE("PlingPlang" == raindrops::convert(15));
 }
-
-TEST_CASE("twenty_one_yields_plingplong")
+TEST_CASE("the_sound_for_21_is_plingplong_as_it_has_factors_3_and_7")
 {
     REQUIRE("PlingPlong" == raindrops::convert(21));
 }
-
-TEST_CASE("twenty_five_yields_plang")
+TEST_CASE("the_sound_for_25_is_plang_as_it_has_a_factor_5")
 {
     REQUIRE("Plang" == raindrops::convert(25));
 }
-
-TEST_CASE("thirty_five_yields_plangplong")
+TEST_CASE("the_sound_for_35_is_plangplong_as_it_has_factors_5_and_7")
 {
     REQUIRE("PlangPlong" == raindrops::convert(35));
 }
-
-TEST_CASE("forty_nine_yields_plong")
+TEST_CASE("the_sound_for_49_is_plong_as_it_has_a_factor_7")
 {
     REQUIRE("Plong" == raindrops::convert(49));
 }
-
-TEST_CASE("fifty_two_yields_itself")
+TEST_CASE("the_sound_for_52_is_52")
 {
     REQUIRE("52" == raindrops::convert(52));
 }
-
-TEST_CASE("one_hundred_five_yields_plingplangplong")
+TEST_CASE("the_sound_for_105_is_plingplangplong_as_it_has_factors_3_5_and_7")
 {
     REQUIRE("PlingPlangPlong" == raindrops::convert(105));
 }

--- a/exercises/practice/raindrops/raindrops_test.cpp
+++ b/exercises/practice/raindrops/raindrops_test.cpp
@@ -80,9 +80,4 @@ TEST_CASE("one_hundred_five_yields_plingplangplong")
 {
     REQUIRE("PlingPlangPlong" == raindrops::convert(105));
 }
-
-TEST_CASE("big_prime_yields_itself")
-{
-    REQUIRE("12121" == raindrops::convert(12121));
-}
 #endif


### PR DESCRIPTION
This brings the raindrops exercise up to date with problem-specifications.

For clarity, it does this in several steps.

1. Rectify tests.toml, removing unimplemented tests.
2. Delete an extraneous test that doesn't exist upstream.
3. Normalize the test descriptions to match the canonical data.
4. Finally, sync with the upstream specification.

This PR supersedes #542, which suggests a manual change to the `instructions.md` file.

Closes #542 