### PR TITLE
Sync acronym with problem-specifications

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.md
+++ b/exercises/practice/acronym/.docs/instructions.md
@@ -4,5 +4,14 @@ Convert a phrase to its acronym.
 
 Techies love their TLA (Three Letter Acronyms)!
 
-Help generate some jargon by writing a program that converts a long name
-like Portable Network Graphics to its acronym (PNG).
+Help generate some jargon by writing a program that converts a long name like Portable Network Graphics to its acronym (PNG).
+
+Punctuation is handled as follows: hyphens are word separators (like whitespace); all other punctuation can be removed from the input.
+
+For example:
+
+|Input|Output|
+|-|-|
+|As Soon As Possible|ASAP|
+|Liquid-crystal display|LCD|
+|Thank George It's Friday!|TGIF|

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,12 +1,12 @@
 {
-  "blurb": "Convert a long phrase to its acronym",
   "authors": [
     "chgraef"
   ],
   "contributors": [
     "elyashiv",
     "KevinWMatthews",
-    "patricksjackson"
+    "patricksjackson",
+    "kytrinyx"
   ],
   "files": {
     "solution": [
@@ -21,6 +21,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Convert a long phrase to its acronym.",
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"
 }

--- a/exercises/practice/acronym/.meta/example.cpp
+++ b/exercises/practice/acronym/.meta/example.cpp
@@ -7,7 +7,7 @@ namespace acronym {
 
 string acronym(string const &input_str) {
     string acronym_str;
-    string delimiters = " :-,";
+    string delimiters = " :-,_";
     enum DelimiterState { NOT_FOUND, FOUND };
     DelimiterState delimiter_state = FOUND;
     for (char c : input_str) {

--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
 description = "basic"
@@ -16,3 +23,15 @@ description = "all caps word"
 
 [ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
 description = "punctuation without whitespace"
+
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"

--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -16,15 +16,3 @@ description = "all caps word"
 
 [ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
 description = "punctuation without whitespace"
-
-[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
-description = "very long abbreviation"
-
-[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
-description = "consecutive delimiters"
-
-[5118b4b1-4572-434c-8d57-5b762e57973e]
-description = "apostrophes"
-
-[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
-description = "underscore emphasis"

--- a/exercises/practice/acronym/acronym_test.cpp
+++ b/exercises/practice/acronym/acronym_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("punctuation")
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("non_acronym_all_caps_word")
+TEST_CASE("all_caps_word")
 {
     const string actual = acronym::acronym("GNU Image Manipulation Program");
 
@@ -44,7 +44,7 @@ TEST_CASE("non_acronym_all_caps_word")
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("hyphenated")
+TEST_CASE("punctuation_without_whitespace")
 {
     const string actual = acronym::acronym("Complementary metal-oxide semiconductor");
 
@@ -52,5 +52,4 @@ TEST_CASE("hyphenated")
 
     REQUIRE(expected == actual);
 }
-
 #endif

--- a/exercises/practice/acronym/acronym_test.cpp
+++ b/exercises/practice/acronym/acronym_test.cpp
@@ -52,4 +52,40 @@ TEST_CASE("punctuation_without_whitespace")
 
     REQUIRE(expected == actual);
 }
+
+TEST_CASE("very_long_abbreviation")
+{
+    const string actual = acronym::acronym("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me");
+
+    const string expected{"ROTFLSHTMDCOALM"};
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("consecutive_delimiters")
+{
+    const string actual = acronym::acronym("Something - I made up from thin air");
+
+    const string expected{"SIMUFTA"};
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("apostrophes")
+{
+    const string actual = acronym::acronym("Halley's Comet");
+
+    const string expected{"HC"};
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("underscore_emphasis")
+{
+    const string actual = acronym::acronym("The Road _Not_ Taken");
+
+    const string expected{"TRNT"};
+
+    REQUIRE(expected == actual);
+}
 #endif

--- a/exercises/practice/acronym/acronym_test.cpp
+++ b/exercises/practice/acronym/acronym_test.cpp
@@ -35,15 +35,6 @@ TEST_CASE("punctuation")
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("all_caps_words")
-{
-    const string actual = acronym::acronym("PHP: Hypertext Preprocessor");
-
-    const string expected{"PHP"};
-
-    REQUIRE(expected == actual);
-}
-
 TEST_CASE("non_acronym_all_caps_word")
 {
     const string actual = acronym::acronym("GNU Image Manipulation Program");


### PR DESCRIPTION
This brings the acronym exercise up to date with problem-specifications.

For clarity, it does this in several steps.

1. Rectify tests.toml, removing unimplemented tests.
2. Delete extraneous tests that don't exist upstream.
3. Normalize the test descriptions to match the canonical data.
4. Finally, sync with the upstream specification.

