### PR TITLE
Add label for on-hold

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -11,6 +11,10 @@
   description: ""
   color: "fc2929"
 
+- name: "on-hold"
+  description: ""
+  color: "cccccc"
+
 - name: "dependencies"
   description: "Pull requests that update a dependency file"
   color: "0366d6"


### PR DESCRIPTION
We need to be able to keep a PR open, but it
has a long-term dependency.

An on-hold label would let us mark the state so we don't
keep looking at it to see why it's not merged yet.
