### PR TITLE
Sync nucleotide-count with problem-specifications

### DIFF
--- a/exercises/practice/nucleotide-count/.docs/instructions.md
+++ b/exercises/practice/nucleotide-count/.docs/instructions.md
@@ -1,10 +1,12 @@
 # Instructions
 
-Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed. All known life depends on DNA!
+Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed.
+All known life depends on DNA!
 
 > Note: You do not need to understand anything about nucleotides or DNA to complete this exercise.
 
-DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine. A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
+DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine.
+A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
 We call the order of these nucleotides in a bit of DNA a "DNA sequence".
 
 We represent a DNA sequence as an ordered collection of these four nucleotides and a common way to do that is with a string of characters such as "ATTACG" for a DNA sequence of 6 nucleotides.
@@ -15,7 +17,7 @@ If the string contains characters that aren't A, C, G, or T then it is invalid a
 
 For example:
 
-```
+```text
 "GATTACA" -> 'A': 3, 'C': 1, 'G': 1, 'T': 2
 "INVALID" -> error
 ```

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -27,5 +27,5 @@
   },
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
-  "source_url": "http://rosalind.info/problems/dna/"
+  "source_url": "https://rosalind.info/problems/dna/"
 }

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [
     "LegalizeAdulthood"
   ],
@@ -26,6 +25,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"
 }

--- a/exercises/practice/nucleotide-count/.meta/example.cpp
+++ b/exercises/practice/nucleotide-count/.meta/example.cpp
@@ -16,13 +16,4 @@ counter::counter(std::string const& sequence)
     }
 }
 
-int counter::count(char nucleotide) const
-{
-    const auto it = counts_.find(nucleotide);
-    if (it == counts_.end()) {
-        throw std::invalid_argument("Unknown nucleotide");
-    }
-    return it->second;
-}
-
 }

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [3e5c30a8-87e2-4845-a815-a49671ade970]
 description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
 
 [eca0d565-ed8c-43e7-9033-6cefbf5115b5]
 description = "strand with repeated nucleotide"

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -5,9 +5,6 @@
 [3e5c30a8-87e2-4845-a815-a49671ade970]
 description = "empty strand"
 
-[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
-description = "can count one nucleotide in single-character input"
-
 [eca0d565-ed8c-43e7-9033-6cefbf5115b5]
 description = "strand with repeated nucleotide"
 

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -18,20 +18,6 @@ TEST_CASE("has_no_nucleotides")
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("has_no_adenosine")
-{
-    const nucleotide_count::counter dna("");
-
-    REQUIRE(0 == dna.count('A'));
-}
-
-TEST_CASE("repetitive_cytidine_gets_counts")
-{
-    const nucleotide_count::counter dna("CCCCC");
-
-    REQUIRE(5 == dna.count('C'));
-}
-
 TEST_CASE("repetitive_sequence_has_only_guanosine")
 {
     const nucleotide_count::counter dna("GGGGGGGG");
@@ -40,29 +26,6 @@ TEST_CASE("repetitive_sequence_has_only_guanosine")
     const auto actual = dna.nucleotide_counts();
 
     REQUIRE(expected == actual);
-}
-
-TEST_CASE("counts_only_thymidine")
-{
-    const nucleotide_count::counter dna("GGGGTAACCCGG");
-
-    REQUIRE(1 == dna.count('T'));
-}
-
-TEST_CASE("counts_a_nucleotide_only_once")
-{
-    const nucleotide_count::counter dna("GGTTGG");
-
-    dna.count('T');
-
-    REQUIRE(2 == dna.count('T'));
-}
-
-TEST_CASE("validates_nucleotides")
-{
-    const nucleotide_count::counter dna("GGTTGG");
-
-    REQUIRE_THROWS_AS(dna.count('X'), std::invalid_argument);
 }
 
 TEST_CASE("validates_nucleotides_on_construction")

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -7,10 +7,10 @@
 #include <map>
 #include <stdexcept>
 
-TEST_CASE("has_no_nucleotides")
+TEST_CASE("empty_strand")
 {
     const nucleotide_count::counter dna("");
-    const std::map<char, int> expected{ {'A', 0}, {'T', 0}, {'C', 0}, {'G', 0} };
+    const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 0}, {'T', 0} };
 
     const auto actual = dna.nucleotide_counts();
 
@@ -18,28 +18,29 @@ TEST_CASE("has_no_nucleotides")
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("repetitive_sequence_has_only_guanosine")
+
+TEST_CASE("strand_with_repeated_nucleotide")
 {
-    const nucleotide_count::counter dna("GGGGGGGG");
-    const std::map<char, int> expected{ {'A', 0}, {'T', 0}, {'C', 0}, {'G', 8} };
+    const nucleotide_count::counter dna("GGGGGGG");
+    const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 7}, {'T', 0} };
 
     const auto actual = dna.nucleotide_counts();
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("counts_all_nucleotides")
+TEST_CASE("strand_with_multiple_nucleotides")
 {
     const nucleotide_count::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
-    std::map<char, int> expected{ {'A', 20}, {'T', 21}, {'G', 17}, {'C', 12} };
+    const std::map<char, int> expected{ {'A', 20}, {'C', 12}, {'G', 17}, {'T', 21} };
 
-    auto actual = dna.nucleotide_counts();
+    const auto actual = dna.nucleotide_counts();
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("validates_nucleotides_on_construction")
+TEST_CASE("strand_with_invalid_nucleotides")
 {
-    REQUIRE_THROWS_AS(nucleotide_count::counter("GGTTGGX"), std::invalid_argument);
+    REQUIRE_THROWS_AS(nucleotide_count::counter("AGXXACT"), std::invalid_argument);
 }
 #endif

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -19,6 +19,16 @@ TEST_CASE("empty_strand")
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
+TEST_CASE("can_count_one_nucleotide_in_single_character_input")
+{
+    const nucleotide_count::counter dna("G");
+    const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 1}, {'T', 0} };
+
+    const auto actual = dna.nucleotide_counts();
+
+    REQUIRE(expected == actual);
+}
+
 TEST_CASE("strand_with_repeated_nucleotide")
 {
     const nucleotide_count::counter dna("GGGGGGG");

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -28,11 +28,6 @@ TEST_CASE("repetitive_sequence_has_only_guanosine")
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("validates_nucleotides_on_construction")
-{
-    REQUIRE_THROWS_AS(nucleotide_count::counter("GGTTGGX"), std::invalid_argument);
-}
-
 TEST_CASE("counts_all_nucleotides")
 {
     const nucleotide_count::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
@@ -41,5 +36,10 @@ TEST_CASE("counts_all_nucleotides")
     auto actual = dna.nucleotide_counts();
 
     REQUIRE(expected == actual);
+}
+
+TEST_CASE("validates_nucleotides_on_construction")
+{
+    REQUIRE_THROWS_AS(nucleotide_count::counter("GGTTGGX"), std::invalid_argument);
 }
 #endif


### PR DESCRIPTION
This brings the nucleotide-counts exercise up to date with problem-specifications.

For clarity, it makes the change in several commits:

1. Delete entries from `tests.toml` that are not reflected in the test suite (per #370)
2. Delete tests from the nucleotide-count test suite that do not have equivalents in the `canonical-data.json`
3. Reorder nucleotide-count tests to reflect the order in `canonical-data.json`
4. Run `configlet fmt` on nucleotide-count to normalize the `config.json`
5. Normalize nucleotide-count tests to use the inputs and test descriptions from the canonical data.
6. Run `configlet sync` for the exercise and implementing the missing test.

Closes #544
Closes #539