### PR TITLE
Sync collatz-conjecture with problem-specifications

### DIFF
--- a/exercises/practice/collatz-conjecture/.docs/instructions.md
+++ b/exercises/practice/collatz-conjecture/.docs/instructions.md
@@ -2,10 +2,11 @@
 
 The Collatz Conjecture or 3x+1 problem can be summarized as follows:
 
-Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
-odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
-The conjecture states that no matter which number you start with, you will
-always reach 1 eventually.
+Take any positive integer n.
+If n is even, divide n by 2 to get n / 2.
+If n is odd, multiply n by 3 and add 1 to get 3n + 1.
+Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will always reach 1 eventually.
 
 Given a number n, return the number of steps required to reach 1.
 
@@ -24,4 +25,5 @@ Starting with n = 12, the steps would be as follows:
 8. 2
 9. 1
 
-Resulting in 9 steps. So for input n = 12, the return value would be 9.
+Resulting in 9 steps.
+So for input n = 12, the return value would be 9.

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -5,7 +5,8 @@
   "contributors": [
     "elyashiv",
     "KevinWMatthews",
-    "patricksjackson"
+    "patricksjackson",
+    "kytrinyx"
   ],
   "files": {
     "solution": [
@@ -20,7 +21,7 @@
       ".meta/example.h"
     ]
   },
-  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture.",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
 }

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [
     "marvelou-s"
   ],
@@ -21,6 +20,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"
 }

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
 description = "zero steps for one"
@@ -16,6 +23,16 @@ description = "large number of even and odd steps"
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
+include = false
+
+[2187673d-77d6-4543-975e-66df6c50e2da]
+description = "zero is an error"
+reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
+include = false
+
+[ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
+description = "negative value is an error"
+reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"

--- a/exercises/practice/collatz-conjecture/collatz_conjecture_test.cpp
+++ b/exercises/practice/collatz-conjecture/collatz_conjecture_test.cpp
@@ -1,8 +1,10 @@
-#include "test/catch.hpp"
 #include "collatz_conjecture.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
+#include "test/catch.hpp"
+#endif
 #include <stdexcept>
-
-// Collatz-conjecture exercise test case data version 1.2.1
 
 TEST_CASE("zero_steps_for_one")
 {
@@ -10,6 +12,7 @@ TEST_CASE("zero_steps_for_one")
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
+
 TEST_CASE("divide_if_even")
 {
     REQUIRE(4 == collatz_conjecture::steps(16));
@@ -34,4 +37,4 @@ TEST_CASE("negative_value_is_an_error")
 {
     REQUIRE_THROWS_AS(collatz_conjecture::steps(-15), std::domain_error);
 }
-#endif // !EXERCISM_RUN_ALL_TESTS
+#endif


### PR DESCRIPTION
The first commit does a wee bit of cleanup to minimize noise in the second commit, which brings the collatz-conjecture exercise up-to-date with the problem-specifications.