### PR TITLE
Sync series with problem-specifications

### DIFF
--- a/exercises/practice/series/.docs/instructions.md
+++ b/exercises/practice/series/.docs/instructions.md
@@ -1,7 +1,6 @@
 # Instructions
 
-Given a string of digits, output all the contiguous substrings of length `n` in
-that string in the order that they appear.
+Given a string of digits, output all the contiguous substrings of length `n` in that string in the order that they appear.
 
 For example, the string "49142" has the following 3-digit series:
 
@@ -14,8 +13,7 @@ And the following 4-digit series:
 - "4914"
 - "9142"
 
-And if you ask for a 6-digit series from a 5-digit string, you deserve
-whatever you get.
+And if you ask for a 6-digit series from a 5-digit string, you deserve whatever you get.
 
-Note that these series are only required to occupy *adjacent positions*
-in the input; the digits need not be *numerically consecutive*.
+Note that these series are only required to occupy *adjacent positions* in the input;
+the digits need not be *numerically consecutive*.

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,5 +1,4 @@
 {
-  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [
     "LegalizeAdulthood"
   ],
@@ -24,6 +23,7 @@
       ".meta/example.h"
     ]
   },
+  "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "source": "A subset of the Problem 8 at Project Euler",
-  "source_url": "http://projecteuler.net/problem=8"
+  "source_url": "https://projecteuler.net/problem=8"
 }

--- a/exercises/practice/series/.meta/example.cpp
+++ b/exercises/practice/series/.meta/example.cpp
@@ -1,30 +1,39 @@
 #include "series.h"
+#include <sstream>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace std;
 
 namespace series
 {
 
-vector<int> digits(string const& sequence)
+inline string slice_me(const string &input, unsigned int start, unsigned int window)
 {
-    vector<int> result;
-    for (const char digit : sequence) {
-        result.push_back(digit - '0');
-    }
-    return result;
+    auto end = start + window;
+    stringstream baby_slice;
+    for (size_t pos = start; pos < end; pos++)
+        baby_slice << input[pos];
+    return baby_slice.str();
 }
 
-vector<vector<int>> slice(string const& sequence, int span)
+string digits(const string &input)
 {
-    if (span > static_cast<int>(sequence.length())) {
-        throw domain_error("Requested span too long for sequence");
-    }
-    vector<vector<int>> result;
-    for (size_t i = 0; i < sequence.length() - (span - 1); ++i) {
-        result.push_back(digits(sequence.substr(i, span)));
-    }
-    return result;
+    return slice_me(input, 0, input.length());
+}
+
+vector<string> slice(const string &input, size_t window)
+{
+    auto len = input.length();
+    if (len < window || window < 1)
+        throw domain_error("Window size must be within size of the slice.");
+    vector<string> ginger_slice;
+    ginger_slice.reserve(len / window);
+    auto end = len - window;
+    for (size_t position = 0; position <= end; position++)
+        ginger_slice.emplace_back(slice_me(input, position, window));
+    return ginger_slice;
 }
 
 }

--- a/exercises/practice/series/.meta/example.h
+++ b/exercises/practice/series/.meta/example.h
@@ -7,9 +7,9 @@
 namespace series
 {
 
-std::vector<int> digits(std::string const& sequence);
+std::string digits(const std::string &input);
 
-std::vector<std::vector<int>> slice(std::string const& sequence, int span);
+std::vector<std::string> slice(const std::string &input, size_t window);
 
 }
 

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
@@ -22,6 +29,10 @@ description = "slices of a long series"
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
+
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
+include = false
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"

--- a/exercises/practice/series/series_test.cpp
+++ b/exercises/practice/series/series_test.cpp
@@ -5,102 +5,80 @@
 #include "test/catch.hpp"
 #endif
 #include <stdexcept>
-
 using namespace std;
 
-TEST_CASE("short_digits")
+TEST_CASE("slices_of_one_from_one")
 {
-    const vector<int> expected{0, 1, 2, 3, 4, 5};
+    const vector<string> expected{ "1" };
 
-    const vector<int> actual{series::digits("012345")};
+    const vector<string> actual{series::slice("1", 1)};
 
     REQUIRE(expected == actual);
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("long_digits")
+TEST_CASE("slices_of_one_from_two")
 {
-    const vector<int> expected{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    const vector<string> expected{ "1", "2" };
 
-    const vector<int> actual{series::digits("0123456789")};
+    const vector<string> actual{series::slice("12", 1)};
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("keeps_the_digit_order_if_reversed")
+TEST_CASE("slices_of_two")
 {
-    const vector<int> expected{9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+    const vector<string> expected{ "35" };
 
-    const vector<int> actual{series::digits("9876543210")};
+    const vector<string> actual{series::slice("35", 2)};
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("keeps_arbitrary_digit_order")
+TEST_CASE("slices_of_two_overlap")
 {
-    const vector<int> expected{9, 3, 6, 9, 2, 3, 4, 6, 8};
+    const vector<string> expected{ "91", "14", "42" };
 
-    const vector<int> actual{series::digits("936923468")};
+    const vector<string> actual{series::slice("9142", 2)};
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("can_slice_by_1")
+TEST_CASE("slices_can_include_duplicates")
 {
-    const vector<vector<int>> expected{{0}, {1}, {2}, {3}, {4}};
+    const vector<string> expected{ "777", "777", "777", "777" };
 
-    const vector<vector<int>> actual{series::slice("01234", 1)};
+    const vector<string> actual{series::slice("777777", 3)};
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("can_slice_by_2")
+TEST_CASE("slices_of_a_long_series")
 {
-    const vector<vector<int>> expected{{9, 8}, {8, 2}, {2, 7}, {7, 3}, {3, 4}, {4, 6}, {6, 3}};
+    const vector<string> expected{ "91849", "18493", "84939", "49390", "93904", "39042", "90424", "04243" };
 
-    const vector<vector<int>> actual{series::slice("98273463", 2)};
+    const vector<string> actual{series::slice("918493904243", 5)};
 
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("can_slice_by_3")
+TEST_CASE("slice_length_is_too_large")
 {
-    const vector<vector<int>> expected{{0, 1, 2}, {1, 2, 3}, {2, 3, 4}};
-
-    const vector<vector<int>> actual{series::slice("01234", 3)};
-
-    REQUIRE(expected == actual);
+    REQUIRE_THROWS_AS(series::slice("12345", 6), domain_error);
 }
 
-TEST_CASE("can_slice_by_3_with_duplicate_digits")
+TEST_CASE("slice_length_cannot_be_zero")
 {
-    const vector<vector<int>> expected{{3, 1, 0}, {1, 0, 0}, {0, 0, 1}};
-
-    const vector<vector<int>> actual{series::slice("31001", 3)};
-
-    REQUIRE(expected == actual);
+    REQUIRE_THROWS_AS(series::slice("12345", 0), domain_error);
 }
 
-TEST_CASE("can_slice_by_4")
+TEST_CASE("slice_length_cannot_be_negative")
 {
-    const vector<vector<int>> expected{{3, 1, 0}, {1, 0, 0}, {0, 0, 1}};
-
-    const vector<vector<int>> actual{series::slice("31001", 3)};
-
-    REQUIRE(expected == actual);
+    REQUIRE_THROWS_AS(series::slice("123", -1), domain_error);
 }
 
-TEST_CASE("can_slice_by_5")
+TEST_CASE("empty_series_is_invalid")
 {
-    const vector<vector<int>> expected{{8, 1, 2, 2, 8}};
-
-    const vector<vector<int>> actual{series::slice("81228", 5)};
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("domain_error_if_not_enough_digits_to_slice")
-{
-    REQUIRE_THROWS_AS(series::slice("01032987583", 12), domain_error);
+    REQUIRE_THROWS_AS(series::slice("", 1), domain_error);
 }
 #endif


### PR DESCRIPTION
I didn't break this into individual steps, because none
of the implemented tests were reflected in the tests.toml.

For this I did a `bin/configlet sync` for the exercise, and then
recreated the test suite.

The canonical specification gives the return values as an array of strings (in JSON), so I changed the expected return type of `slice` to `vector<string>` instead of `vector<vector<int>>`.

I haven't yet changed the example solution to pass the tests; once I've got it passing I'll update the PR to be ready for review.

Closes #536