### PR TITLE
Update min required Ubuntu version to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linux-min:
     name: Linux Min Config
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         compiler: [clang++-6.0, g++-7]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        compiler: [clang++-6.0, g++-7]
+        compiler: [clang++-6.0, g++-10]
     steps:
     - uses: actions/checkout@v3
     - name: Install Dependencies
       # Boost must be installed only because the CMake version (3.12) can't
       # detect the installed Boost version (1.69)
-      run: sudo apt-get update && sudo apt-get -y install ninja-build libboost-date-time-dev clang-6.0 g++-7 g++-multilib
+      run: sudo apt-get update && sudo apt-get -y install ninja-build libboost-date-time-dev clang-6.0 g++-10 g++-multilib
     - name: Run tests with common Catch
       run: |
         cmake -G Ninja .


### PR DESCRIPTION
> CI: .github#L1
> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

Ubuntu 18.04 will be phased out in GitHub actions. We should not wait too long to change along. That would also free the track from using clang 6 with C++14 to clang 10 with C++17.