### PR TITLE
queen-attack: Re-add test for distinct positions

### DIFF
--- a/exercises/practice/queen-attack/queen_attack_test.cpp
+++ b/exercises/practice/queen-attack/queen_attack_test.cpp
@@ -50,6 +50,13 @@ TEST_CASE("newly_placed_queen_must_have_column_on_board")
     REQUIRE_THROWS_AS((queen_attack::chess_board{white, black}), std::domain_error);
 }
 
+TEST_CASE("queen_positions_must_be_distinct")
+{
+    const auto pos = std::make_pair(3, 7);
+
+    REQUIRE_THROWS_AS((queen_attack::chess_board{pos, pos}), std::domain_error);
+}
+
 TEST_CASE("queens_cannot_attack")
 {
     const queen_attack::chess_board board{std::make_pair(2, 4), std::make_pair(6, 6)};


### PR DESCRIPTION
Before PR #554 this exercise has a test that required the constructor to throw an exception if the positions of the two queens were identical. This PR recovers the test.