### PR TITLE
nucleotide-count: convert the class to a function

### DIFF
--- a/exercises/practice/nucleotide-count/.meta/example.cpp
+++ b/exercises/practice/nucleotide-count/.meta/example.cpp
@@ -4,16 +4,17 @@
 namespace nucleotide_count
 {
 
-counter::counter(std::string const& sequence)
-    : counts_({ {'A', 0}, {'C', 0}, {'G', 0}, {'T', 0} })
+std::map<char, int> count(std::string_view dna)
 {
-    for (auto nucleotide : sequence) {
-        auto it = counts_.find(nucleotide);
-        if (it == counts_.end()) {
+    std::map<char, int> counter{{'A', 0}, {'C', 0}, {'G', 0}, {'T', 0}};
+    for (auto nucleotide : dna) {
+        auto it = counter.find(nucleotide);
+        if (it == counter.end()) {
             throw std::invalid_argument("Unknown nucleotide");
         }
         ++(it->second);
     }
+    return counter;
 }
 
 }

--- a/exercises/practice/nucleotide-count/.meta/example.h
+++ b/exercises/practice/nucleotide-count/.meta/example.h
@@ -2,26 +2,12 @@
 #define NUCLEOTIDE_COUNT_H
 
 #include <map>
-#include <string>
+#include <string_view>
 
 namespace nucleotide_count
 {
 
-class counter
-{
-public:
-    counter(std::string const& sequence);
-
-    std::map<char, int> const& nucleotide_counts() const
-    {
-        return counts_;
-    }
-
-    int count(char nucleotide) const;
-
-private:
-    std::map<char, int> counts_;
-};
+std::map<char, int> count(std::string_view dna);
 
 }
 

--- a/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/practice/nucleotide-count/nucleotide_count_test.cpp
@@ -9,10 +9,8 @@
 
 TEST_CASE("empty_strand")
 {
-    const nucleotide_count::counter dna("");
     const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 0}, {'T', 0} };
-
-    const auto actual = dna.nucleotide_counts();
+    const auto actual = nucleotide_count::count("");
 
     REQUIRE(expected == actual);
 }
@@ -21,36 +19,30 @@ TEST_CASE("empty_strand")
 
 TEST_CASE("can_count_one_nucleotide_in_single_character_input")
 {
-    const nucleotide_count::counter dna("G");
     const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 1}, {'T', 0} };
-
-    const auto actual = dna.nucleotide_counts();
+    const auto actual = nucleotide_count::count("G");
 
     REQUIRE(expected == actual);
 }
 
 TEST_CASE("strand_with_repeated_nucleotide")
 {
-    const nucleotide_count::counter dna("GGGGGGG");
     const std::map<char, int> expected{ {'A', 0}, {'C', 0}, {'G', 7}, {'T', 0} };
-
-    const auto actual = dna.nucleotide_counts();
+    const auto actual = nucleotide_count::count("GGGGGGG");
 
     REQUIRE(expected == actual);
 }
 
 TEST_CASE("strand_with_multiple_nucleotides")
 {
-    const nucleotide_count::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
     const std::map<char, int> expected{ {'A', 20}, {'C', 12}, {'G', 17}, {'T', 21} };
-
-    const auto actual = dna.nucleotide_counts();
+    const auto actual = nucleotide_count::count("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
 
     REQUIRE(expected == actual);
 }
 
 TEST_CASE("strand_with_invalid_nucleotides")
 {
-    REQUIRE_THROWS_AS(nucleotide_count::counter("AGXXACT"), std::invalid_argument);
+    REQUIRE_THROWS_AS(nucleotide_count::count("AGXXACT"), std::invalid_argument);
 }
 #endif


### PR DESCRIPTION
Before PR #550 the constructor was required to validate the input, the member function `count(char)` had to return the count for a specific nucleotide, the member function `nucleotide_counts()` had to return a `std::map` with all four counts.

But PR #550 has changed that significantly. After syncing the tests with the canonical data there's no call to `count(char)` anymore, so each test looks like a two-step function call:

```
const nucleotide_count::counter dna("G");
const auto actual = dna.nucleotide_counts();
```

I'd call that unnecessarily complicated and unidiomatic, there's no longer a good reason to require a `class`. Let's turn the class `counter` into a function:

```
const auto actual = nucleotide_count::count("G");
```