### PR TITLE
lasagna: Fix CMakeLists.txt

### DIFF
--- a/exercises/concept/lasagna/CMakeLists.txt
+++ b/exercises/concept/lasagna/CMakeLists.txt
@@ -20,19 +20,19 @@ endif()
 # Use the common Catch library?
 if(EXERCISM_COMMON_CATCH)
     # For Exercism track development only
-    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h $<TARGET_OBJECTS:catchlib>)
+    add_executable(${exercise} ${file}_test.cpp $<TARGET_OBJECTS:catchlib>)
 elseif(EXERCISM_TEST_SUITE)
     # The Exercism test suite is being run, the Docker image already
     # includes a pre-built version of Catch.
     find_package(Catch2 REQUIRED)
-    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
+    add_executable(${exercise} ${file}_test.cpp)
     target_link_libraries(${exercise} PRIVATE Catch2::Catch2WithMain)
     # When Catch is installed system wide we need to include a different
     # header, we need this define to use the correct one.
     target_compile_definitions(${exercise} PRIVATE EXERCISM_TEST_SUITE)
 else()
     # Build executable from sources and headers
-    add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h test/tests-main.cpp)
+    add_executable(${exercise} ${file}_test.cpp test/tests-main.cpp)
 endif()
 
 set_target_properties(${exercise} PROPERTIES


### PR DESCRIPTION
This first exercise should be as simple as possible, so we're not using a `.h` file but including the `.cpp` file directly in the the tests. This requires a minor deviation from the `CMakeLists.txt` of the other exercises.