### PR TITLE
Remove comment reference to another exercise

### DIFF
--- a/exercises/practice/protein-translation/protein_translation_test.cpp
+++ b/exercises/practice/protein-translation/protein_translation_test.cpp
@@ -9,8 +9,6 @@
 
 using namespace std;
 
-// Secret-handshake exercise test case data version 1.2.1
-
 TEST_CASE("Methionine_RNA_sequence")
 {
     REQUIRE(vector<string>{"Methionine"} == protein_translation::proteins("AUG"));


### PR DESCRIPTION
Seems to be a copy paste or template error from another exercise (secret handshake)