### PR TITLE
Basics Concept: Ignore unused parameters during compilation

### DIFF
--- a/exercises/concept/lasagna/CMakeLists.txt
+++ b/exercises/concept/lasagna/CMakeLists.txt
@@ -45,7 +45,9 @@ set(CMAKE_BUILD_TYPE Debug)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror"
+        # added "-Wno-unused-parameter" to remove compiler warnings
+        # should make it easier for students to run their first real code
+        COMPILE_FLAGS "-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter"
     )
 endif()
 


### PR DESCRIPTION
Ignores compiler warnings for unused variables to let students reach the test screen, even when they have not yet implemented everything.