### PR TITLE
 Concept docs for "Namespaces" (closes #605)

### DIFF
--- a/concepts/namespaces/.meta/config.json
+++ b/concepts/namespaces/.meta/config.json
@@ -1,0 +1,8 @@
+{
+  "blurb": "Code can be organized in namespaces for a clearer structure.",
+  "authors": [
+    "vaeng"
+  ],
+  "contributors": [
+  ]
+}

--- a/concepts/namespaces/about.md
+++ b/concepts/namespaces/about.md
@@ -1,6 +1,31 @@
 # About
 
-[comment]: # (Copy content from introduction, once it is agreed upoon)
+An important method for code organization are namespaces.
+Two functions might have a naming collision, which can be resolved by putting them in different namespaces.
+Namespaces can be nested, which might help to structure big code bases.
+Access to the namespaces is done via the scope-resolution operator `::`.
+
+The example below shows the use of two different `foo` functions.
+They are used together by prefixing their respective namespaces.
+
+```cpp
+namespace my_ns {
+    int foo() {
+        return 44;
+    }
+    namespace my_inner_ns {
+        int baz() {
+            return 90;
+        }
+    }
+}
+namespace my_other_ns {
+    int foo() {
+        return -2;
+    }
+}
+int myresult{my_ns::foo() + my_other_ns::foo() * my_ns::my_inner_ns::baz()};
+```
 
 ~~~~exercism/advanced
 Deeply nested namespaces might be too verbose.

--- a/concepts/namespaces/about.md
+++ b/concepts/namespaces/about.md
@@ -1,0 +1,22 @@
+# About
+
+[comment]: # (Copy content from introduction, once it is agreed upoon)
+
+~~~~exercism/advanced
+Deeply nested namespaces might be too verbose.
+It is possible to remove the verbosity with a namespace import via `using`.
+This moves all names into the global namespace.
+To keep some differentiation aliases might be useful.
+
+```cpp
+int my_other_result{my_ns::my_inner_ns::baz()};
+
+using namespace my_ns::my_inner_ns; // importing the complete namespace
+int also_other_result{baz()};
+
+namespace m = my_ns; // setting an alias
+namespace o = my_other_ns;
+
+int also_my_result{m::foo() + o::foo() * m::my_inner_ns::baz()};
+```
+~~~~

--- a/concepts/namespaces/introduction.md
+++ b/concepts/namespaces/introduction.md
@@ -1,0 +1,29 @@
+# Introduction
+
+An important method for code organization are namespaces.
+Two functions might have a naming collision, which can be resolved by putting them in different namespaces.
+Namespaces can be nested, which might help to structure big code bases.
+Access to the namespaces is done via the scope-resolution operator `::`.
+
+The example below shows the use of two different `foo` functions.
+They are used together by prefixing their respective namespaces.
+
+```cpp
+namespace my_ns {
+    int foo() {
+        return 44;
+    }
+    namespace my_inner_ns {
+        int baz() {
+            return 90;
+        }
+    }
+}
+namespace my_other_ns {
+    int foo() {
+        return -2;
+    }
+}
+
+int myresult{my_ns::foo() + my_other_ns::foo() * my_ns::my_inner_ns::baz()};
+```

--- a/concepts/namespaces/links.json
+++ b/concepts/namespaces/links.json
@@ -1,0 +1,6 @@
+[
+    {
+        "url": "https://en.cppreference.com/w/cpp/language/namespace",
+        "description": "C++ reference on namespaces"
+    }
+]

--- a/config.json
+++ b/config.json
@@ -820,7 +820,13 @@
       "uuid": "e52453a5-4997-4eba-b754-5bda7b97c701",
       "slug": "basics",
       "name": "Basics"
+    },
+    {
+      "uuid": "7b9bcf07-b447-4c18-b838-a7f4167ff521",
+      "slug": "namespaces",
+      "name": "Namespaces"
     }
+
   ],
   "key_features": [
     {

--- a/config.json
+++ b/config.json
@@ -826,7 +826,6 @@
       "slug": "namespaces",
       "name": "Namespaces"
     }
-
   ],
   "key_features": [
     {


### PR DESCRIPTION
This is the first smaller package to deliver the same content as the previous "Code Organization" concept.
The wording is almost the same as the previous pr #598 

There will be some more for headers, includes, and forward declarations, but namespaces are pretty independent.