### PR TITLE
[Fix] String/Include Concept exercise order

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,11 +42,12 @@
         "name": "Log Levels",
         "uuid": "62f945e7-0791-46b7-8161-855183f736ba",
         "concepts": [
-          "strings"
+          "strings",
+          "includes"
         ],
         "prerequisites": [
           "basics",
-          "includes"
+          "namespaces"
         ],
         "status": "wip"
       },


### PR DESCRIPTION
Log-Levels should teach includes and strings while having namespaces as a prerequisite.