### PR TITLE
[interest-is-interesting]: Correct Link Formatting in `hints.md` File

### DIFF
--- a/exercises/concept/interest-is-interesting/.docs/hints.md
+++ b/exercises/concept/interest-is-interesting/.docs/hints.md
@@ -15,8 +15,8 @@
 
 ## 4. Calculate the years before reaching the desired balance
 
-- To calculate the years, one can keep looping until the desired balance is reached using a [`for` loop][for].
+- To calculate the years, one can keep looping until the desired balance is reached using a [`for`][for] loop.
 - There is a special [operator][increment] to increment values by 1.
 
-[for] : https://www.learncpp.com/cpp-tutorial/introduction-to-loops-and-while-statements/
-[increment] : https://www.learncpp.com/cpp-tutorial/increment-decrement-operators-and-side-effects/
+[for]: https://www.learncpp.com/cpp-tutorial/introduction-to-loops-and-while-statements/
+[increment]: https://www.learncpp.com/cpp-tutorial/increment-decrement-operators-and-side-effects/


### PR DESCRIPTION
Addresses #642 

Weirdly, it looks as if reflinks need to be formatted like:

`[<linkname>]: <url>` and not `[<linkname>] : <url>`

That extra space before the colon apparently does something icky.