### PR TITLE
[Improvement] Add information for featured exercises

### DIFF
--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,0 +1,13 @@
+This exercise uses the [`unordered_set`][set].
+You probably need the `emplace` function to add elements to the set.
+
+You might stumble across [`const`][const] because it has not come up in the syllabus yet.
+When it prefixes a variable, it works like a safeguard.
+`const` variables cannot be changed.
+The exercise also features the [`unsigned`][unsigned] keyword.
+This doubles the range of the prefixed integer, but will not let it turn negative.
+
+
+[set]: https://en.cppreference.com/w/cpp/container/unordered_set
+[const]: https://www.learncpp.com/cpp-tutorial/const-variables-and-symbolic-constants/
+[unsigned]: https://www.learncpp.com/cpp-tutorial/unsigned-integers-and-why-to-avoid-them/

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,13 +1,18 @@
-This exercise uses the [`unordered_set`][set].
-You probably need the `emplace` function to add elements to the set.
+# Instructions append
+ 
+## Some Additional Notes for C++ Implementation
+
+This exercise uses the [`unordered_set`][set]
+You probably need the [`emplace`][emplace] function to add elements to the set.
 
 You might stumble across [`const`][const] because it has not come up in the syllabus yet.
 When it prefixes a variable, it works like a safeguard.
 `const` variables cannot be changed.
-The exercise also features the [`unsigned`][unsigned] keyword.
+This exercise also features the [`unsigned`][unsigned] keyword.
 This doubles the range of the prefixed integer, but will not let it turn negative.
 
 
 [set]: https://en.cppreference.com/w/cpp/container/unordered_set
+[emplace]: https://en.cppreference.com/w/cpp/container/vector/emplace
 [const]: https://www.learncpp.com/cpp-tutorial/const-variables-and-symbolic-constants/
 [unsigned]: https://www.learncpp.com/cpp-tutorial/unsigned-integers-and-why-to-avoid-them/

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+ 
+## Some Additional Notes for C++ Implementation
+
 This exercise uses the [vector container][vector].
 You might find it useful to use the [algorithm][algorithm] header to solve this exercise.
 

--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -1,5 +1,11 @@
 This exercise uses the [vector container][vector].
 You might find it useful to use the [algorithm][algorithm] header to solve this exercise.
+
+Some of the algorithm functions need [`iterators`][iterator] as arguments.
+Those can be seen as markers of where a container starts and ends.
+If you want to cover the complete container, you start with `my_container.begin()` and end with `my_container.end()`.
+If you just want the elements 2, 3, and 4 of a vector you could use `my_vector.begin() + 2` and `my_vector.begin() + 4`.
+
 The last tests check for [immutability][immutability].
 None of the functions that you are tasked to write should change the scores of the game.
 
@@ -8,3 +14,4 @@ If you want some extra practice, you can implement a function that adds new scor
 [vector]: https://en.cppreference.com/w/cpp/container/vector
 [algorithm]: https://en.cppreference.com/w/cpp/algorithm
 [immutability]: https://en.wikipedia.org/wiki/Immutable_object
+[iterator]: https://www.learncpp.com/cpp-tutorial/introduction-to-iterators/


### PR DESCRIPTION
Two exercises cover topics / concept, that are not (yet) in the syllabus, so I gave them a bit more implementation hints in the `instructions.append.md` 