### PR TITLE
[Practice Exercise Lint]: General Markdown Cleanup, Link Checks, Spelling,  & Docs Sync.

### DIFF
--- a/exercises/practice/acronym/.docs/instructions.md
+++ b/exercises/practice/acronym/.docs/instructions.md
@@ -10,8 +10,8 @@ Punctuation is handled as follows: hyphens are word separators (like whitespace)
 
 For example:
 
-|Input|Output|
-|-|-|
-|As Soon As Possible|ASAP|
-|Liquid-crystal display|LCD|
-|Thank George It's Friday!|TGIF|
+| Input                     	| Output 	|
+|---------------------------	|--------	|
+| As Soon As Possible       	| ASAP   	|
+| Liquid-crystal display    	| LCD    	|
+| Thank George It's Friday! 	| TGIF   	|

--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,8 +1,13 @@
 # Instructions
 
-An anagram is a rearrangement of letters to form a new word.
-Given a word and a list of candidates, select the sublist of anagrams of the given word.
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
 
-Given `"listen"` and a list of candidates like `"enlists" "google"
-"inlets" "banana"` the program should return a list containing
-`"inlets"`.
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.

--- a/exercises/practice/armstrong-numbers/.docs/instructions.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
 
@@ -10,3 +10,5 @@ For example:
 - 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
 
 Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number

--- a/exercises/practice/atbash-cipher/.docs/instructions.md
+++ b/exercises/practice/atbash-cipher/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+Create an implementation of the Atbash cipher, an ancient encryption system created in the Middle East.
 
 The Atbash cipher is a simple substitution cipher that relies on
 transposing all the letters in the alphabet such that the resulting
@@ -15,12 +15,12 @@ Cipher: zyxwvutsrqponmlkjihgfedcba
 ```
 
 It is a very weak cipher because it only has one possible key, and it is
-a simple monoalphabetic substitution cipher. However, this may not have
-been an issue in the cipher's time.
+a simple monoalphabetic substitution cipher.
+However, this may not have been an issue in the cipher's time.
 
 Ciphertext is written out in groups of fixed length, the traditional group size
-being 5 letters, and punctuation is excluded. This is to make it harder to guess
-things based on word boundaries.
+being 5 letters, and punctuation is excluded.
+This is to make it harder to guess things based on word boundaries.
 
 ## Examples
 

--- a/exercises/practice/binary/.docs/instructions.md
+++ b/exercises/practice/binary/.docs/instructions.md
@@ -3,8 +3,8 @@
 Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.
 
 Implement binary to decimal conversion. Given a binary input
-string, your program should produce a decimal output. The
-program should handle invalid inputs.
+string, your program should produce a decimal output.
+The program should handle invalid inputs.
 
 ## Note
 

--- a/exercises/practice/bob/.docs/instructions.md
+++ b/exercises/practice/bob/.docs/instructions.md
@@ -1,16 +1,19 @@
 # Instructions
 
-Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+Your task is to determine what Bob will reply to someone when they say something to him or ask him a question.
 
-Bob answers 'Sure.' if you ask him a question, such as "How are you?".
+Bob only ever answers one of five things:
 
-He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
-
-He answers 'Calm down, I know what I'm doing!' if you yell a question at him.
-
-He says 'Fine. Be that way!' if you address him without actually saying
-anything.
-
-He answers 'Whatever.' to anything else.
-
-Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
+- **"Sure."**
+  This is his response if you ask him a question, such as "How are you?"
+  The convention used for questions is that it ends with a question mark.
+- **"Whoa, chill out!"**
+  This is his answer if you YELL AT HIM.
+  The convention used for yelling is ALL CAPITAL LETTERS.
+- **"Calm down, I know what I'm doing!"**
+  This is what he says if you yell a question at him.
+- **"Fine. Be that way!"**
+  This is how he responds to silence.
+  The convention used for silence is nothing, or various combinations of whitespace characters.
+- **"Whatever."**
+  This is what he answers to anything else.

--- a/exercises/practice/bob/.docs/introduction.md
+++ b/exercises/practice/bob/.docs/introduction.md
@@ -1,0 +1,10 @@
+# Introduction
+
+Bob is a [lackadaisical][] teenager.
+He likes to think that he's very cool.
+And he definitely doesn't get excited about things.
+That wouldn't be cool.
+
+When people talk to him, his responses are pretty limited.
+
+[lackadaisical]: https://www.collinsdictionary.com/dictionary/english/lackadaisical

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -13,5 +13,5 @@ ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
 You are not expected to discover an efficient solution to this yourself from
-first principles; research is allowed, indeed, encouraged. Finding the best
-algorithm for the problem is a key skill in software engineering.
+first principles; research is allowed, indeed, encouraged.
+Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -13,5 +13,4 @@ ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
 You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
-first principles; research is allowed, indeed, encouraged.
 Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/difference-of-squares/.docs/instructions.md
+++ b/exercises/practice/difference-of-squares/.docs/instructions.md
@@ -12,6 +12,6 @@ Hence the difference between the square of the sum of the first
 ten natural numbers and the sum of the squares of the first ten
 natural numbers is 3025 - 385 = 2640.
 
-You are not expected to discover an efficient solution to this yourself from
+You are not expected to discover an efficient solution to this yourself from first principles; research is allowed, indeed, encouraged.
 first principles; research is allowed, indeed, encouraged.
 Finding the best algorithm for the problem is a key skill in software engineering.

--- a/exercises/practice/queen-attack/.docs/instructions.md
+++ b/exercises/practice/queen-attack/.docs/instructions.md
@@ -21,5 +21,5 @@ So if you are told the white queen is at `c5` (zero-indexed at column 2, row 3) 
   a b c d e f g h
 ```
 
-You are also be able to answer whether the queens can attack each other.
+You are also able to answer whether the queens can attack each other.
 In this case, that answer would be yes, they can, because both pieces share a diagonal.

--- a/exercises/practice/simple-linked-list/.docs/instructions.append.md
+++ b/exercises/practice/simple-linked-list/.docs/instructions.append.md
@@ -11,4 +11,4 @@ The tests use the functions as they are supplied in `simple_linked_list.cpp`, do
 
 ## Can I use smart pointers?
 
-Although the header-file includes raw pointers, you are free to chose a different implementation.
+Although the header-file includes raw pointers, you are free to choose a different implementation.

--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -4,20 +4,26 @@ Determine if a triangle is equilateral, isosceles, or scalene.
 
 An _equilateral_ triangle has all three sides the same length.
 
-An _isosceles_ triangle has at least two sides the same length. (It is sometimes
-specified as having exactly two sides the same length, but for the purposes of
-this exercise we'll say at least two.)
+An _isosceles_ triangle has at least two sides the same length.
+(It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)
 
 A _scalene_ triangle has all sides of different lengths.
 
 ## Note
 
-For a shape to be a triangle at all, all sides have to be of length > 0, and
-the sum of the lengths of any two sides must be greater than or equal to the
-length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side.
 
-## Dig Deeper
+In equations:
 
-The case where the sum of the lengths of two sides _equals_ that of the
-third is known as a _degenerate_ triangle - it has zero area and looks like
-a single line. Feel free to add your own code/tests to check for degenerate triangles.
+Let `a`, `b`, and `c` be sides of the triangle.
+Then all three of the following expressions must be true:
+
+```text
+a + b ≥ c
+b + c ≥ a
+a + c ≥ b
+```
+
+See [Triangle Inequality][triangle-inequality]
+
+[triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality


### PR DESCRIPTION
Went through the practice exercises to check general Markdown formatting, links, and anything else that jumped out.
Changes below:

- [x] Acronym (_corrected table formatting_)
- [x] Anagram (_updated `instructions.md` from problem specs_)
- [x] Armstrong Numbers (_changed in-line link to a ref-link_)
- [x] Atbash Cipher (_corrected capitalization and one-sentence-per-line_)
- [x] Binary (_corrected one-sentence-per-line_)
- [x] Bob (_synced with problem specs `instructions.md` --> `introduction.md` & `instructions.md`_)
- [x] Difference of Squares (_corrected one-sentence-per-line_)
- [x] Queen-attack:  (_corrected grammar on 2nd to last line._)
- [x] Simple-Linked-List (_fixed chose --> choose typo_)
- [x] Triangle (_synced `instructions.md` to problem specs_)

If any of these look hanky, happy to back them out.  😄   