### PR TITLE
lasagna: fix two typos

### DIFF
--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -99,7 +99,7 @@ int total_fee(int vips, int adults, int kids) {
 Functions in C++ do not return the value of the last statement like in some other languages.
 The `return` keyword is required for the code to compile.
 
-#### Whitespace
+### Whitespace
 
 Whitespace is used for formatting source code and includes spaces, tabs, or newlines.
 As the compiler ignores unnecessary whitespace, you can use it to structure your code.

--- a/exercises/concept/lasagna/lasagna.cpp
+++ b/exercises/concept/lasagna/lasagna.cpp
@@ -5,8 +5,8 @@ int ovenTime() {
     return 0;
 }
 
-/* RemainingOvenTime returns the remaining
-    minutes based on the actual minutes already in the oven.
+/* remainingOvenTime returns the remaining
+   minutes based on the actual minutes already in the oven.
 */
 int remainingOvenTime(int actualMinutesInOven) {
     // TODO: Calculate and return the remaining in the oven based on the time


### PR DESCRIPTION
Two small typos:
- the name of the function remainingOvenTime starts with an uppercase R in the comment
- the heading for the section "Whitespace" has a different level (`####`) than the headings of the other sections (`###`)