### PR TITLE
[Fix] Concept - Loops: floating point testing

### DIFF
--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
@@ -8,7 +8,7 @@
 TEST_CASE("Minimal first interest rate", "[task1]") {
     double balance{0};
     double want{0.5};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
@@ -16,137 +16,137 @@ TEST_CASE("Minimal first interest rate", "[task1]") {
 TEST_CASE("Tiny first interest rate", "[task1]") {
     double balance{0.000001};
     double want{0.5};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Maximum first interest rate", "[task1]") {
     double balance{999.9999};
     double want{0.5};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Minimal second interest rate", "[task1]") {
     double balance{1000.0};
     double want{1.621};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Tiny second interest rate", "[task1]") {
     double balance{1000.0001};
     double want{1.621};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Maximum second interest rate", "[task1]") {
     double balance{4999.9990};
     double want{1.621};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Minimal third interest rate", "[task1]") {
     double balance{5000.0000};
     double want{2.475};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Tiny third interest rate", "[task1]") {
     double balance{5000.0001};
     double want{2.475};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Large third interest rate", "[task1]") {
     double balance{5639998.742909};
     double want{2.475};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Rate on minimal negative balance", "[task1]") {
     double balance{-0.000001};
     double want{3.213};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Rate on small negative balance", "[task1]") {
     double balance{-0.123};
     double want{3.213};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Rate on regular negative balance", "[task1]") {
     double balance{-300.0};
     double want{3.213};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Rate on large negative balance", "[task1]") {
     double balance{-152964.231};
     double want{3.213};
-    REQUIRE(interest_rate(balance) == want);
+    REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Interest on negative balance", "[task2]") {
     double balance{-10000.0};
     double want{-321.3};
-    REQUIRE(yearly_interest(balance) == want);
+    REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 TEST_CASE("Interest on small balance", "[task2]") {
     double balance{555.43};
     double want{2.77715};
-    REQUIRE(yearly_interest(balance) == want);
+    REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 TEST_CASE("Interest on medium balance", "[task2]") {
     double balance{4999.99};
     double want{81.0498379};
-    REQUIRE(yearly_interest(balance) == want);
+    REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 TEST_CASE("Interest on large balance", "[task2]") {
     double balance{34600.80};
     double want{856.3698};
-    REQUIRE(yearly_interest(balance) == want);
+    REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for empty start balance", "[task3]") {
     double balance{0.0};
     double want{0.0000};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for small positive start balance", "[task3]") {
     double balance{0.000001};
     double want{0.000001005};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for average positive start balance",
           "[task3]") {
     double balance{1000.0};
     double want{1016.210000};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for large positive start balance", "[task3]") {
     double balance{1000.2001};
     double want{1016.413343621};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for huge positive start balance", "[task3]") {
     double balance{898124017.826243404425};
     double want{920352587.2674429417};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for small negative start balance", "[task3]") {
     double balance{-0.123};
     double want{-0.12695199};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Annual balance update for large negative start balance", "[task3]") {
     double balance{-152964.231};
     double want{-157878.97174203};
-    REQUIRE(annual_balance_update(balance) == want);
+    REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
 TEST_CASE("Years before desired balance for small start balance") {


### PR DESCRIPTION
Change tests to account for some rounding errors.

The way the testing is done currently pretty much only accepts the order of the exemplar solution and that should not hinder students from passing.