### PR TITLE
Strengthen tests in Vehicle Purchase exercise

### DIFF
--- a/exercises/concept/troll-the-trolls/.docs/introduction.md
+++ b/exercises/concept/troll-the-trolls/.docs/introduction.md
@@ -92,7 +92,7 @@ We then declare each one of the conditions with the `case` keyword.
 We can also declare a `default` case, that will run when none of the previous `case` conditions matched.
 Each case should end with a `break` (or a `return`) statement.
 
-We can also declare a `default` case, that will run when none of the previous `case` conditions match.
+```cpp
 int price{0};
 int adults{3};
 int kids{2};
@@ -111,10 +111,10 @@ switch (int group_size{adults + kids}) {
 
 ## Fall-through
 
-One important thing about the switch construct is that the code will continue to execute until it is stopped by a `break` statement.
+One important thing about the switch construct is that the code will continue to execute until it is stopped by a `break` (or a `return`) statement.
 This can lead to unexpected behavior.
 
-One important thing about the switch construct is that the code will continue to execute until it is stopped by a `break` (or a `return`) statement.
+```cpp
 int adults{1};
 int kids{0};
 switch (int group_size{adults + kids}) {


### PR DESCRIPTION
Current tests for choose_vehicle allow a simplistic implementation of
return option1 + " is clearly the better choice.";
to pass all tests without comparing option1 and option2.

This is due to the current tests all passing in option1 and option2 sorted in lexicographic order already.

This change swaps option1 and option2 for a couple of the tests which forces the implementation to compare the parameters.

This change will not impact existing solutions that are correctly implemented.