### PR TITLE
feature(test-runner): add task_id for all concept ex

### DIFF
--- a/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
+++ b/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
@@ -32,9 +32,7 @@ TEST_CASE("Alien is always hit", "[task_1]") {
     REQUIRE(alien.hit());
 }
 
-TEST_CASE(
-    "Alien is alive while health is greater than 0 and stays dead afterwards",
-    "[task_3]") {
+TEST_CASE("Alien is alive while health is greater than 0 and stays dead afterwards", "[task_3]") {
     Alien alien{2, 54};
     REQUIRE(alien.is_alive());
     alien.hit();

--- a/exercises/concept/freelancer-rates/freelancer_rates_test.cpp
+++ b/exercises/concept/freelancer-rates/freelancer_rates_test.cpp
@@ -7,53 +7,53 @@
 
 using namespace std;
 
-TEST_CASE("it's the hourly_rate times 8") { REQUIRE(daily_rate(50) == 400.0); }
+TEST_CASE("it's the hourly_rate times 8", "[task_1]") { REQUIRE(daily_rate(50) == 400.0); }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
-TEST_CASE("it always returns a float") { REQUIRE(daily_rate(60) == 480.0); }
+TEST_CASE("it always returns a float", "[task_1]") { REQUIRE(daily_rate(60) == 480.0); }
 
-TEST_CASE("it does not round") { REQUIRE(daily_rate(55.1) == 440.8); }
+TEST_CASE("it does not round", "[task_1]") { REQUIRE(daily_rate(55.1) == 440.8); }
 
-TEST_CASE("a discount of 10 percent leaves 90 percent of the original price") {
+TEST_CASE("a discount of 10 percent leaves 90 percent of the original price", "[task_2]") {
     REQUIRE(apply_discount(140.0, 10) == 126.0);
 }
 
-TEST_CASE("it doesn't round") {
+TEST_CASE("it doesn't round", "[task_2]") {
     // If unsure about the syntax of this test see:
     // https://github.com/catchorg/Catch2/blob/devel/docs/comparing-floating-point-numbers.md#withinrel
     REQUIRE_THAT(apply_discount(111.11, 13.5),
                  Catch::Matchers::WithinRel(96.11015, 0.000001));
 }
 
-TEST_CASE("it's the daily_rate times 22") {
+TEST_CASE("it's the daily_rate times 22", "[task_3]") {
     REQUIRE(monthly_rate(62, 0.0) == 10'912);
 }
 
-TEST_CASE("the result is rounded up") {
+TEST_CASE("the result is rounded up", "[task_3]") {
     // 11_052.8
     REQUIRE(monthly_rate(62.8, 0.0) == 11'053);
     // 11_475.2
     REQUIRE(monthly_rate(65.2, 0.0) == 11'476);
 }
 
-TEST_CASE("gives a discount") {
+TEST_CASE("gives a discount", "[task_3]") {
     // 11'792 - 12% * 11_792 = 10'376.96
     REQUIRE(monthly_rate(67, 12.0) == 10'377);
 }
 
-TEST_CASE("it's the budget divided by the daily rate") {
+TEST_CASE("it's the budget divided by the daily rate", "[task_4]") {
     REQUIRE(days_in_budget(1'600, 50, 0.0) == 4);
 }
 
-TEST_CASE("it rounds down to next decimal place") {
+TEST_CASE("it rounds down to next decimal place", "[task_4]") {
     //  9.97727
     REQUIRE(days_in_budget(4'390, 55, 0.0) == 9);
     // 10.18182
     REQUIRE(days_in_budget(4'480, 55, 0.0) == 10);
 }
 
-TEST_CASE("it applies the discount") {
+TEST_CASE("it applies the discount", "[task_4]") {
     // Without discount: 0.8
     // With discount: 1.07
     REQUIRE(days_in_budget(480, 70, 20) == 1);

--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
@@ -5,7 +5,7 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("Minimal first interest rate", "[task1]") {
+TEST_CASE("Minimal first interest rate", "[task_1]") {
     double balance{0};
     double want{0.5};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
@@ -13,179 +13,178 @@ TEST_CASE("Minimal first interest rate", "[task1]") {
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
-TEST_CASE("Tiny first interest rate", "[task1]") {
+TEST_CASE("Tiny first interest rate", "[task_1]") {
     double balance{0.000001};
     double want{0.5};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Maximum first interest rate", "[task1]") {
+TEST_CASE("Maximum first interest rate", "[task_1]") {
     double balance{999.9999};
     double want{0.5};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Minimal second interest rate", "[task1]") {
+TEST_CASE("Minimal second interest rate", "[task_1]") {
     double balance{1000.0};
     double want{1.621};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Tiny second interest rate", "[task1]") {
+TEST_CASE("Tiny second interest rate", "[task_1]") {
     double balance{1000.0001};
     double want{1.621};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Maximum second interest rate", "[task1]") {
+TEST_CASE("Maximum second interest rate", "[task_1]") {
     double balance{4999.9990};
     double want{1.621};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Minimal third interest rate", "[task1]") {
+TEST_CASE("Minimal third interest rate", "[task_1]") {
     double balance{5000.0000};
     double want{2.475};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Tiny third interest rate", "[task1]") {
+TEST_CASE("Tiny third interest rate", "[task_1]") {
     double balance{5000.0001};
     double want{2.475};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Large third interest rate", "[task1]") {
+TEST_CASE("Large third interest rate", "[task_1]") {
     double balance{5639998.742909};
     double want{2.475};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Rate on minimal negative balance", "[task1]") {
+TEST_CASE("Rate on minimal negative balance", "[task_1]") {
     double balance{-0.000001};
     double want{3.213};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Rate on small negative balance", "[task1]") {
+TEST_CASE("Rate on small negative balance", "[task_1]") {
     double balance{-0.123};
     double want{3.213};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Rate on regular negative balance", "[task1]") {
+TEST_CASE("Rate on regular negative balance", "[task_1]") {
     double balance{-300.0};
     double want{3.213};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Rate on large negative balance", "[task1]") {
+TEST_CASE("Rate on large negative balance", "[task_1]") {
     double balance{-152964.231};
     double want{3.213};
     REQUIRE_THAT(interest_rate(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Interest on negative balance", "[task2]") {
+TEST_CASE("Interest on negative balance", "[task_2]") {
     double balance{-10000.0};
     double want{-321.3};
     REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
-TEST_CASE("Interest on small balance", "[task2]") {
+TEST_CASE("Interest on small balance", "[task_2]") {
     double balance{555.43};
     double want{2.77715};
     REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
-TEST_CASE("Interest on medium balance", "[task2]") {
+TEST_CASE("Interest on medium balance", "[task_2]") {
     double balance{4999.99};
     double want{81.0498379};
     REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
-TEST_CASE("Interest on large balance", "[task2]") {
+TEST_CASE("Interest on large balance", "[task_2]") {
     double balance{34600.80};
     double want{856.3698};
     REQUIRE_THAT(yearly_interest(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for empty start balance", "[task3]") {
+TEST_CASE("Annual balance update for empty start balance", "[task_3]") {
     double balance{0.0};
     double want{0.0000};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for small positive start balance", "[task3]") {
+TEST_CASE("Annual balance update for small positive start balance", "[task_3]") {
     double balance{0.000001};
     double want{0.000001005};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for average positive start balance",
-          "[task3]") {
+TEST_CASE("Annual balance update for average positive start balance", "[task_3]") {
     double balance{1000.0};
     double want{1016.210000};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for large positive start balance", "[task3]") {
+TEST_CASE("Annual balance update for large positive start balance", "[task_3]") {
     double balance{1000.2001};
     double want{1016.413343621};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for huge positive start balance", "[task3]") {
+TEST_CASE("Annual balance update for huge positive start balance", "[task_3]") {
     double balance{898124017.826243404425};
     double want{920352587.2674429417};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for small negative start balance", "[task3]") {
+TEST_CASE("Annual balance update for small negative start balance", "[task_3]") {
     double balance{-0.123};
     double want{-0.12695199};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Annual balance update for large negative start balance", "[task3]") {
+TEST_CASE("Annual balance update for large negative start balance", "[task_3]") {
     double balance{-152964.231};
     double want{-157878.97174203};
     REQUIRE_THAT(annual_balance_update(balance), Catch::Matchers::WithinRel(want, 0.000001));
 }
 
-TEST_CASE("Years before desired balance for small start balance") {
+TEST_CASE("Years before desired balance for small start balance", "[task_4]") {
     double balance{100.0};
     double target_balance{125.80};
     int want{47};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Years before desired balance for average start balance") {
+TEST_CASE("Years before desired balance for average start balance", "[task_4]") {
     double balance{1000.0};
     double target_balance{1100.0};
     int want{6};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Years before desired balance for large start balance") {
+TEST_CASE("Years before desired balance for large start balance", "[task_4]") {
     double balance{8080.80};
     double target_balance{9090.90};
     int want{5};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Years before large difference between start and target balance") {
+TEST_CASE("Years before large difference between start and target balance", "[task_4]") {
     double balance{2345.67};
     double target_balance{12345.6789};
     int want{85};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Balance is already above target") {
+TEST_CASE("Balance is already above target", "[task_4]") {
     double balance{2345.67};
     double target_balance{2345.0};
     int want{0};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Balance is exactly same as target") {
+TEST_CASE("Balance is exactly same as target", "[task_4]") {
     double balance{2345.0};
     double target_balance{2345.0};
     int want{0};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
-TEST_CASE("Result balance would be exactly same as target") {
+TEST_CASE("Result balance would be exactly same as target", "[task_4]") {
     double balance{1000.0};
     double target_balance{1032.6827641};
     int want{2};

--- a/exercises/concept/lasagna/lasagna_test.cpp
+++ b/exercises/concept/lasagna/lasagna_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-TEST_CASE("Preparation time correct") {
+TEST_CASE("Preparation time correct", "[task_1]") {
     int actual = 40;
     int expected = ovenTime();
 
@@ -15,25 +15,8 @@ TEST_CASE("Preparation time correct") {
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("Correct for six layers") {
-    int timePerLayer = 2;
-    int layers = 6;
-    int actual = preparationTime(layers);
-    int expected{timePerLayer * layers};
 
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("Correct for 11 layers") {
-    int timePerLayer = 2;
-    int layers = 11;
-    int actual = preparationTime(layers);
-    int expected{timePerLayer * layers};
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("Fresh in the oven") {
+TEST_CASE("Fresh in the oven", "[task_2]") {
     int timeSpendInOven = 0;
     int neededBakeTime = 40;
     int actual = remainingOvenTime(timeSpendInOven);
@@ -42,7 +25,7 @@ TEST_CASE("Fresh in the oven") {
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("Halfway done") {
+TEST_CASE("Halfway done", "[task_2]") {
     int timeSpendInOven = 20;
     int neededBakeTime = 40;
     int actual = remainingOvenTime(timeSpendInOven);
@@ -51,7 +34,25 @@ TEST_CASE("Halfway done") {
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("Fresh in the oven, 12 layers!") {
+TEST_CASE("Correct for six layers", "[task_3]") {
+    int timePerLayer = 2;
+    int layers = 6;
+    int actual = preparationTime(layers);
+    int expected{timePerLayer * layers};
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("Correct for 11 layers", "[task_3]") {
+    int timePerLayer = 2;
+    int layers = 11;
+    int actual = preparationTime(layers);
+    int expected{timePerLayer * layers};
+
+    REQUIRE(expected == actual);
+}
+
+TEST_CASE("Fresh in the oven, 12 layers!", "[task_4]") {
     int timeSpendInOven = 0;
     int timePerLayer = 2;
     int layers = 11;
@@ -61,7 +62,7 @@ TEST_CASE("Fresh in the oven, 12 layers!") {
     REQUIRE(expected == actual);
 }
 
-TEST_CASE("One minute left, 5 layers!") {
+TEST_CASE("One minute left, 5 layers!", "[task_4]") {
     int timeSpendInOven = 39;
     int timePerLayer = 2;
     int layers = 5;

--- a/exercises/concept/last-will/last_will_test.cpp
+++ b/exercises/concept/last-will/last_will_test.cpp
@@ -13,7 +13,12 @@ namespace estate_executor {
 
 using namespace std;
 
-TEST_CASE("Family secrets have not been altered") {
+TEST_CASE("Family secrets have not been altered", "[task_1]") {
+    // We cannot test the existence of a namespace in the compiled 
+    // Code.
+    // This test merely checks if the numbers in the file have 
+    // been changed. They have to be correct for the test to work.
+
     REQUIRE(zhang::bank_number_part(1) == 8541);
     REQUIRE(zhang::bank_number_part(3) == 8541 * 3 % 10'000);
     REQUIRE(khan::bank_number_part(1) == 4142);
@@ -30,13 +35,13 @@ TEST_CASE("Family secrets have not been altered") {
     REQUIRE(garcia::blue::code_fragment() == 923);
 }
 
-TEST_CASE("Account number assembly function exists in correct namespace") {
+TEST_CASE("Account number assembly function exists in correct namespace", "[task_2]") {
     REQUIRE_NOTHROW(estate_executor::assemble_account_number(0));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
-TEST_CASE("Account number assembly works correctly") {
+TEST_CASE("Account number assembly works correctly", "[task_2]") {
     int account_with_secret_1{16706};
     int account_with_secret_23{14238};
 
@@ -44,11 +49,11 @@ TEST_CASE("Account number assembly works correctly") {
     REQUIRE(estate_executor::assemble_account_number(23) == account_with_secret_23);
 }
 
-TEST_CASE("Code fragment number assembly function exists in correct namespace") {
+TEST_CASE("Code fragment number assembly function exists in correct namespace", "[task_3]") {
     REQUIRE_NOTHROW(estate_executor::assemble_code());
 }
 
-TEST_CASE("Code fragments fit correctly") {
+TEST_CASE("Code fragments fit correctly", "[task_3]") {
     int final_code{1925550};
 
     REQUIRE(estate_executor::assemble_code() == final_code);

--- a/exercises/concept/log-levels/log_levels_test.cpp
+++ b/exercises/concept/log-levels/log_levels_test.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-TEST_CASE("Error message")
+TEST_CASE("Error message", "[task_1]")
 {
     const string actual = log_line::message("[ERROR]: Stack overflow");
 
@@ -17,7 +17,7 @@ TEST_CASE("Error message")
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("Warning message")
+TEST_CASE("Warning message", "[task_1]")
 {
     const string actual = log_line::message("[WARNING]: Disk almost full");
 
@@ -26,7 +26,7 @@ TEST_CASE("Warning message")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Info message")
+TEST_CASE("Info message", "[task_1]")
 {
     const string actual = log_line::message("[INFO]: File moved");
 
@@ -35,7 +35,7 @@ TEST_CASE("Info message")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Error log level")
+TEST_CASE("Error log level", "[task_2]")
 {
     const string actual = log_line::log_level("[ERROR]: Disk full");
 
@@ -44,7 +44,7 @@ TEST_CASE("Error log level")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Warning log level")
+TEST_CASE("Warning log level", "[task_2]")
 {
     const string actual = log_line::log_level("[WARNING]: Unsafe password");
 
@@ -53,7 +53,7 @@ TEST_CASE("Warning log level")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Info log level")
+TEST_CASE("Info log level", "[task_2]")
 {
     const string actual = log_line::log_level("[INFO]: Timezone changed");
 
@@ -62,7 +62,7 @@ TEST_CASE("Info log level")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Error reformat")
+TEST_CASE("Error reformat", "[task_3]")
 {
     const string actual = log_line::reformat("[ERROR]: Segmentation fault");
 
@@ -71,7 +71,7 @@ TEST_CASE("Error reformat")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Warning reformat")
+TEST_CASE("Warning reformat", "[task_3]")
 {
     const string actual = log_line::reformat("[WARNING]: Decreased performance");
 
@@ -80,7 +80,7 @@ TEST_CASE("Warning reformat")
     REQUIRE(actual == expected);
 }
 
-TEST_CASE("Info reformat")
+TEST_CASE("Info reformat", "[task_3]")
 {
     const string actual = log_line::reformat("[INFO]: Disk defragmented");
 

--- a/exercises/concept/pacman-rules/pacman_rules_test.cpp
+++ b/exercises/concept/pacman-rules/pacman_rules_test.cpp
@@ -6,57 +6,57 @@
 #endif
 
 
-TEST_CASE( "ghost gets eaten") {
+TEST_CASE( "ghost gets eaten", "[task_1]") {
   REQUIRE( can_eat_ghost(true, true));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
-TEST_CASE( "ghost does not get eaten because no power pellet active") {
+TEST_CASE( "ghost does not get eaten because no power pellet active", "[task_1]") {
   REQUIRE_FALSE( can_eat_ghost(false, true));
 }
 
-TEST_CASE( "ghost does not get eaten because not touching ghost") {
+TEST_CASE( "ghost does not get eaten because not touching ghost", "[task_1]") {
   REQUIRE_FALSE( can_eat_ghost(true, false));
 }
 
-TEST_CASE( "ghost does not get eaten because no power pellet is active, even if not touching ghost") {
+TEST_CASE( "ghost does not get eaten because no power pellet is active, even if not touching ghost", "[task_1]") {
   REQUIRE_FALSE( can_eat_ghost(false, false));
 }
     
-TEST_CASE("score when eating dot") {
+TEST_CASE("score when eating dot", "[task_2]") {
   REQUIRE( scored(false, true));
 }
 
-TEST_CASE("score when eating power pellet") {
+TEST_CASE("score when eating power pellet", "[task_2]") {
   REQUIRE( scored(true, false));
 }
 
-TEST_CASE("no score when nothing eaten") {
+TEST_CASE("no score when nothing eaten", "[task_2]") {
   REQUIRE_FALSE( scored(false, false));
 }
     
-TEST_CASE("lose if touching a ghost without a power pellet active") {
+TEST_CASE("lose if touching a ghost without a power pellet active", "[task_3]") {
   REQUIRE( lost(false, true));
 }
 
-TEST_CASE("don't lose if touching a ghost with a power pellet active") {
+TEST_CASE("don't lose if touching a ghost with a power pellet active", "[task_3]") {
   REQUIRE_FALSE( lost(true, true));
 }
 
-TEST_CASE("don't lose if not touching a ghost") {
+TEST_CASE("don't lose if not touching a ghost", "[task_3]") {
   REQUIRE_FALSE( lost(true, false));
 }
 
-TEST_CASE( "win if all dots eaten") {
+TEST_CASE( "win if all dots eaten", "[task_4]") {
       REQUIRE( won(true, false, false));
 }
 
-TEST_CASE( "don't win if all dots eaten, but touching a ghost") {
+TEST_CASE( "don't win if all dots eaten, but touching a ghost", "[task_4]") {
       REQUIRE_FALSE( won(true, false, true));
 }
 
-TEST_CASE( "win if all dots eaten and touching a ghost with a power pellet active") {
+TEST_CASE( "win if all dots eaten and touching a ghost with a power pellet active", "[task_4]") {
       REQUIRE( won(true, true, true));
 }
 

--- a/exercises/concept/vehicle-purchase/vehicle_purchase_test.cpp
+++ b/exercises/concept/vehicle-purchase/vehicle_purchase_test.cpp
@@ -6,97 +6,97 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("need a license for a car") {
+TEST_CASE("need a license for a car", "[task_1]") {
     std::string kind{"car"};
     REQUIRE(vehicle_purchase::needs_license(kind));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 
-TEST_CASE("need a license for a truck") {
+TEST_CASE("need a license for a truck", "[task_1]") {
     std::string kind{"truck"};
     REQUIRE(vehicle_purchase::needs_license(kind));
 }
-TEST_CASE("does not need a license for a bike") {
+TEST_CASE("does not need a license for a bike", "[task_1]") {
     std::string kind{"bike"};
     REQUIRE_FALSE(vehicle_purchase::needs_license(kind));
 }
-TEST_CASE("does not need a license for a stroller") {
+TEST_CASE("does not need a license for a stroller", "[task_1]") {
     std::string kind{"stroller"};
     REQUIRE_FALSE(vehicle_purchase::needs_license(kind));
 }
-TEST_CASE("does not need a license for a e-scooter") {
+TEST_CASE("does not need a license for a e-scooter", "[task_1]") {
     std::string kind{"e-scooter"};
     REQUIRE_FALSE(vehicle_purchase::needs_license(kind));
 }
 
-TEST_CASE("chooses Bugatti over Ford") {
+TEST_CASE("chooses Bugatti over Ford", "[task_2]") {
     std::string choice1{"Bugatti Veyron"};
     std::string choice2{"Ford Pinto"};
     REQUIRE(vehicle_purchase::choose_vehicle(choice1, choice2) ==
             "Bugatti Veyron is clearly the better choice.");
 }
-TEST_CASE("chooses Chery over Kia") {
+TEST_CASE("chooses Chery over Kia", "[task_2]") {
     std::string choice1{"Kia Niro Elektro"};
     std::string choice2{"Chery EQ"};
     REQUIRE(vehicle_purchase::choose_vehicle(choice1, choice2) ==
             "Chery EQ is clearly the better choice.");
 }
-TEST_CASE("chooses Ford Focus over Ford Pinto") {
+TEST_CASE("chooses Ford Focus over Ford Pinto", "[task_2]") {
     std::string choice1{"Ford Focus"};
     std::string choice2{"Ford Pinto"};
     REQUIRE(vehicle_purchase::choose_vehicle(choice1, choice2) ==
             "Ford Focus is clearly the better choice.");
 }
-TEST_CASE("chooses 2018 over 2020") {
+TEST_CASE("chooses 2018 over 2020", "[task_2]") {
     std::string choice1{"2020 Gazelle Medeo"};
     std::string choice2{"2018 Bergamont City"};
     REQUIRE(vehicle_purchase::choose_vehicle(choice1, choice2) ==
             "2018 Bergamont City is clearly the better choice.");
 }
-TEST_CASE("chooses Bugatti over ford") {
+TEST_CASE("chooses Bugatti over ford", "[task_2]") {
     std::string choice1{"Bugatti Veyron"};
     std::string choice2{"ford"};
     REQUIRE(vehicle_purchase::choose_vehicle(choice1, choice2) ==
             "Bugatti Veyron is clearly the better choice.");
 }
 
-TEST_CASE("price is reduced to 80% for age of 2") {
+TEST_CASE("price is reduced to 80% for age of 2", "[task_3]") {
     double original_price{40000};
     double age{2};
     double expected{32000};
     REQUIRE(vehicle_purchase::calculate_resell_price(original_price, age) ==
             expected);
 }
-TEST_CASE("price is reduced to 80% for age of 2.5") {
+TEST_CASE("price is reduced to 80% for age of 2.5", "[task_3]") {
     double original_price{40000};
     double age{2.5};
     double expected{32000};
     REQUIRE(vehicle_purchase::calculate_resell_price(original_price, age) ==
             expected);
 }
-TEST_CASE("price is reduced to 70% for age 7") {
+TEST_CASE("price is reduced to 70% for age 7", "[task_3]") {
     double original_price{40000};
     double age{7};
     double expected{28000};
     REQUIRE(vehicle_purchase::calculate_resell_price(original_price, age) ==
             expected);
 }
-TEST_CASE("price is reduced to 50% for age 10") {
+TEST_CASE("price is reduced to 50% for age 10", "[task_3]") {
     double original_price{25000};
     double age{10};
     double expected{12500};
     REQUIRE(vehicle_purchase::calculate_resell_price(original_price, age) ==
             expected);
 }
-TEST_CASE("price is reduced to 50% for age 11") {
+TEST_CASE("price is reduced to 50% for age 11", "[task_3]") {
     double original_price{50000};
     double age{11};
     double expected{25000};
     REQUIRE(vehicle_purchase::calculate_resell_price(original_price, age) ==
             expected);
 }
-TEST_CASE("float price is reduced to 70% for age 8,") {
+TEST_CASE("float price is reduced to 70% for age 8,", "[task_3]") {
     double original_price{39000.000001};
     double age{8};
     double expected{27300.0000007};

--- a/exercises/practice/complex-numbers/complex_numbers_test.cpp
+++ b/exercises/practice/complex-numbers/complex_numbers_test.cpp
@@ -171,16 +171,14 @@ TEST_CASE("Absolute value of a negative purely real number") {
 }
 
 TEST_CASE(
-    "Absolute value of a purely imaginary number with positive imaginary "
-    "part") {
+    "Absolute value of a purely imaginary number with positive imaginary part") {
     const Complex c{0.0, 5.0};
 
     REQUIRE(Approx(5.0) == c.abs());
 }
 
 TEST_CASE(
-    "Absolute value of a purely imaginary number with negative imaginary "
-    "part") {
+    "Absolute value of a purely imaginary number with negative imaginary part") {
     const Complex c{0.0, -5.0};
 
     REQUIRE(Approx(5.0) == c.abs());

--- a/exercises/practice/high-scores/high_scores_test.cpp
+++ b/exercises/practice/high-scores/high_scores_test.cpp
@@ -66,8 +66,7 @@ TEST_CASE("Personal top when there is only one", "[personalTopThree]") {
     REQUIRE(hs.top_three() == expected);
 }
 
-TEST_CASE("Latest score after personal top scores",
-          "[immutable, latestAfterTopThree]") {
+TEST_CASE("Latest score after personal top scores", "[immutable, latestAfterTopThree]") {
     // Test if latest_score is still valid after calling top_three
     std::vector<int> scores{70, 50, 20, 30};
     int expected{30};
@@ -76,8 +75,7 @@ TEST_CASE("Latest score after personal top scores",
     REQUIRE(hs.latest_score() == expected);
 }
 
-TEST_CASE("Scores after personal top scores",
-          "[immutable, scoresAfterTopThree]") {
+TEST_CASE("Scores after personal top scores", "[immutable, scoresAfterTopThree]") {
     // Test if list_scores is unchanged after calling top_three
     std::vector<int> scores{30, 50, 20, 70};
     arcade::HighScores hs{scores};


### PR DESCRIPTION
This PR adds the necessary task_id information to every concept exercise test file.
This will just change the parsing of the test file and show the tests grouped by task.
It will not change the tests themselves. It is thus not needed to redo the tests.

The commit will need the `[no important files changed]` in the body.
The forum's discussion will give more information if anyone is interested:
https://forum.exercism.org/t/maintainers-new-no-important-files-changed-flag-added/6500

