### PR TITLE
fix: change test to work with Catch2 v2 and v3

### DIFF
--- a/exercises/practice/complex-numbers/complex_numbers_test.cpp
+++ b/exercises/practice/complex-numbers/complex_numbers_test.cpp
@@ -26,45 +26,47 @@ static const double eps = 0.005;
 
 // Helper function for comparing Complex numbers with approximate float values.
 static void require_approx_equal(const Complex& lhs, const Complex& rhs) {
-    REQUIRE(Approx(lhs.real()).margin(eps) == rhs.real());
-    REQUIRE(Approx(lhs.imag()).margin(eps) == rhs.imag());
+    REQUIRE_THAT(lhs.real(),
+                 Catch::Matchers::WithinAbs(rhs.real(), eps));
+    REQUIRE_THAT(lhs.imag(),
+                 Catch::Matchers::WithinAbs(rhs.imag(), eps));
 }
 
 TEST_CASE("Real part of a purely real number") {
     const Complex c{1.0, 0.0};
 
-    REQUIRE(Approx(1.0) == c.real());
+    REQUIRE_THAT(c.real(), Catch::Matchers::WithinAbs(1.0, eps));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 TEST_CASE("Real part of a purely imaginary number") {
     const Complex c{0.0, 1.0};
 
-    REQUIRE(Approx(0.0).margin(eps) == c.real());
+    REQUIRE_THAT(c.real(), Catch::Matchers::WithinAbs(0.0, eps));
 }
 
 TEST_CASE("Real part of a number with real and imaginary part") {
     const Complex c{1.0, 2.0};
 
-    REQUIRE(Approx(1.0) == c.real());
+    REQUIRE_THAT(c.real(), Catch::Matchers::WithinAbs(1.0, eps));
 }
 
 TEST_CASE("Imaginary part of a purely real number") {
     const Complex c{1.0, 0.0};
 
-    REQUIRE(Approx(0.0).margin(eps) == c.imag());
+    REQUIRE_THAT(c.imag(), Catch::Matchers::WithinAbs(0.0, eps));
 }
 
 TEST_CASE("Imaginary part of a purely imaginary number") {
     const Complex c{0.0, 1.0};
 
-    REQUIRE(Approx(1.0) == c.imag());
+    REQUIRE_THAT(c.imag(), Catch::Matchers::WithinAbs(1.0, eps));
 }
 
 TEST_CASE("Imaginary part of a number with real and imaginary part") {
     const Complex c{1.0, 2.0};
 
-    REQUIRE(Approx(2.0) == c.imag());
+    REQUIRE_THAT( c.imag(), Catch::Matchers::WithinAbs(2.0, eps));
 }
 
 TEST_CASE("Imaginary unit") {
@@ -161,13 +163,13 @@ TEST_CASE("Divide numbers with real and imaginary part") {
 TEST_CASE("Absolute value of a positive purely real number") {
     const Complex c{5.0, 0.0};
 
-    REQUIRE(Approx(5.0) == c.abs());
+    REQUIRE_THAT(c.abs(), Catch::Matchers::WithinAbs(5.0, eps));
 }
 
 TEST_CASE("Absolute value of a negative purely real number") {
     const Complex c{-5.0, 0.0};
 
-    REQUIRE(Approx(5.0) == c.abs());
+    REQUIRE_THAT(c.abs(), Catch::Matchers::WithinAbs(5.0, eps));
 }
 
 TEST_CASE(
@@ -175,7 +177,7 @@ TEST_CASE(
     "part") {
     const Complex c{0.0, 5.0};
 
-    REQUIRE(Approx(5.0) == c.abs());
+    REQUIRE_THAT(c.abs(), Catch::Matchers::WithinAbs(5.0, eps));
 }
 
 TEST_CASE(
@@ -183,13 +185,13 @@ TEST_CASE(
     "part") {
     const Complex c{0.0, -5.0};
 
-    REQUIRE(Approx(5.0) == c.abs());
+    REQUIRE_THAT(c.abs(), Catch::Matchers::WithinAbs(5.0, eps));
 }
 
 TEST_CASE("Absolute value of a number with real and imaginary part") {
     const Complex c{3.0, 4.0};
 
-    REQUIRE(Approx(5.0) == c.abs());
+    REQUIRE_THAT(c.abs(), Catch::Matchers::WithinAbs(5.0, eps));
 }
 
 TEST_CASE("Conjugate a purely real number") {

--- a/exercises/practice/space-age/space_age_test.cpp
+++ b/exercises/practice/space-age/space_age_test.cpp
@@ -22,64 +22,62 @@ TEST_CASE("age_in_earth_years")
 {
     const space_age::space_age age(1000000000);
 
-    // 'Approx' is a helper from the test suite for comparing floating point
-    // numbers.
-    REQUIRE(age.on_earth() == Approx(31.69).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(31.69, accuracy));
 }
 
 TEST_CASE("age_in_mercury_years")
 {
     const space_age::space_age age(2134835688);
 
-    REQUIRE(age.on_earth() == Approx(67.65).margin(accuracy));
-    REQUIRE(age.on_mercury() == Approx(280.88).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(67.65, accuracy));
+    REQUIRE_THAT(age.on_mercury(), Catch::Matchers::WithinAbs(280.88, accuracy));
 }
 
 TEST_CASE("age_in_venus_years")
 {
     const space_age::space_age age(189839836);
 
-    REQUIRE(age.on_earth() == Approx(6.02).margin(accuracy));
-    REQUIRE(age.on_venus() == Approx(9.78).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(6.02, accuracy));
+    REQUIRE_THAT(age.on_venus(), Catch::Matchers::WithinAbs(9.78, accuracy));
 }
 
 TEST_CASE("age_in_mars_years")
 {
     const space_age::space_age age(2329871239);
 
-    REQUIRE(age.on_earth() == Approx(73.83).margin(accuracy));
-    REQUIRE(age.on_mars() == Approx(39.25).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(73.83, accuracy));
+    REQUIRE_THAT(age.on_mars(), Catch::Matchers::WithinAbs(39.25, accuracy));
 }
 
 TEST_CASE("age_in_jupiter_years")
 {
     const space_age::space_age age(901876382);
 
-    REQUIRE(age.on_earth() == Approx(28.58).margin(accuracy));
-    REQUIRE(age.on_jupiter() == Approx(2.41).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(28.58, accuracy));
+    REQUIRE_THAT(age.on_jupiter(), Catch::Matchers::WithinAbs(2.41, accuracy));
 }
 
 TEST_CASE("age_in_saturn_years")
 {
     const space_age::space_age age(3000000000);
 
-    REQUIRE(age.on_earth() == Approx(95.06).margin(accuracy));
-    REQUIRE(age.on_saturn() == Approx(3.23).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(95.06, accuracy));
+    REQUIRE_THAT(age.on_saturn(), Catch::Matchers::WithinAbs(3.23, accuracy));
 }
 
 TEST_CASE("age_in_uranus_years")
 {
     const space_age::space_age age(3210123456);
 
-    REQUIRE(age.on_earth() == Approx(101.72).margin(accuracy));
-    REQUIRE(age.on_uranus() == Approx(1.21).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(101.72, accuracy));
+    REQUIRE_THAT(age.on_uranus(), Catch::Matchers::WithinAbs(1.21, accuracy));
 }
 
 TEST_CASE("age_in_neptune_year")
 {
     const space_age::space_age age(8210123456);
 
-    REQUIRE(age.on_earth() == Approx(260.16).margin(accuracy));
-    REQUIRE(age.on_neptune() == Approx(1.58).margin(accuracy));
+    REQUIRE_THAT(age.on_earth(), Catch::Matchers::WithinAbs(260.16, accuracy));
+    REQUIRE_THAT(age.on_neptune(), Catch::Matchers::WithinAbs(1.58, accuracy));
 }
 #endif


### PR DESCRIPTION
Catch2 has been updated to v3 in the test-runner.
The old approximation to compare floating point numbers is outdated. This PR commit fixes the issue.

Although test files have been touched, the old solutions should no be re-run!
[no important files changed]

Thanks to @siebenschlaefer  for reporting the issue!