### PR TITLE
fix(test): correct includes to work with v3 runner

### DIFF
--- a/exercises/practice/circular-buffer/circular_buffer_test.cpp
+++ b/exercises/practice/circular-buffer/circular_buffer_test.cpp
@@ -1,5 +1,10 @@
-#include "test/catch.hpp"
 #include "circular_buffer.h"
+#ifdef EXERCISM_TEST_SUITE
+#include <catch2/catch.hpp>
+#else
+#include "test/catch.hpp"
+#endif
+
 #include <stdexcept>
 
 // Circular-buffer exercise test case data version 1.2.0


### PR DESCRIPTION
All exercises have been tested via the docker image to check compatibility with the new Catch2 v3. In the end, it was only the circular-buffer exercise that still caused problems.

The includes were not in the standard form and caused a problem. Existing solutions do not need retesting, the change only affects the test-runner automation.

Closes #704
[no important files changed]