### PR TITLE
Fixed incorrect type declaration in Introduction Docs

### DIFF
--- a/exercises/concept/ellens-alien-game/.docs/introduction.md
+++ b/exercises/concept/ellens-alien-game/.docs/introduction.md
@@ -30,7 +30,7 @@ Notice the `;` after the definition:
 ```cpp
 class Wizard {
   public:               // from here on all members are publicly accessible
-    inc cast_spell() {  // defines the public member function cast_spell
+    int cast_spell() {  // defines the public member function cast_spell
       return damage;
     }
     std::string name{}; // defines the public member variable `name`


### PR DESCRIPTION
Fixed a non-issue typo. In "introduction" docs for Ellens_Alien_Game , the term "inc" is used instead of declaring an "int". Could be very confusing for a beginner. 