### PR TITLE
election-day/task_4: prevent collateral changes

### DIFF
--- a/exercises/concept/election-day/.meta/exemplar.cpp
+++ b/exercises/concept/election-day/.meta/exemplar.cpp
@@ -29,12 +29,13 @@ void increment_vote_count(ElectionResult& result, int votes) {
 // in the form of a `reference` to `std::vector<ElectionResult>`, a vector with
 // `ElectionResults` of all the participating candidates.
 ElectionResult& determine_result(std::vector<ElectionResult>& count) {
-    ElectionResult& winner = count.at(0);
+    int winner_idx = 0;
     for (int i{}; i < count.size(); ++i) {
-        if(count.at(i).votes > winner.votes) {
-            winner = count.at(i);
+        if(count.at(i).votes > count.at(winner_idx).votes) {
+            winner_idx = i;
         }
     }
+    ElectionResult& winner = count.at(winner_idx);
     winner.name = "President " + winner.name;
     return winner;
 }

--- a/exercises/concept/election-day/election_day_test.cpp
+++ b/exercises/concept/election-day/election_day_test.cpp
@@ -77,4 +77,21 @@ TEST_CASE("Presidency, several candidates", "[task_3]") {
     REQUIRE(result.name == expected);
 }
 
+TEST_CASE("Presidency, votes and other results do not change", "[task_3]") {
+    ElectionResult option1{"Tammy Metzler", 0};
+    ElectionResult option2{"Tracy Flick", 257};
+    ElectionResult option3{"Paul Metzler", 256};
+    std::vector<ElectionResult> final_count{option1, option2, option3};
+
+    determine_result(final_count);
+
+    REQUIRE(final_count.size() == 3);
+    REQUIRE(final_count[0].name == "Tammy Metzler");
+    REQUIRE(final_count[0].votes == 0);
+    REQUIRE(final_count[1].name == "President Tracy Flick");
+    REQUIRE(final_count[1].votes == 257);
+    REQUIRE(final_count[2].name == "Paul Metzler");
+    REQUIRE(final_count[2].votes == 256);
+}
+
 #endif


### PR DESCRIPTION
Currently many solutions modify not only the result of the winner but also other results in the process.  
This fix prevents those changes by adding another test.