### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -30,13 +30,13 @@ int tomatoes{80};
 int potatoes = 40;
 ```
 
-```exercism/caution
+~~~~exercism/caution
 C++ does allow using uninitialized variables.
 Until the variable is deliberately set, it is undefined and might contain anything.
 To avoid used-before-set errors and undefined behavior it is adviseable to **always initialize**.
 Undefined behavior can crash your program at the worst possible moment, while it was running fine previously.
 It cannot be stressed enough: avoid undefined behavior at all cost.
-```
+~~~~
 
 ## Arithmetic Operations
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -30,13 +30,13 @@ int tomatoes{80};
 int potatoes = 40;
 ```
 
-```exercism/caution
+~~~~exercism/caution
 C++ does allow using uninitialized variables.
 Until the variable is deliberately set, it is undefined and might contain anything.
 To avoid used-before-set errors and undefined behavior it is adviseable to **always initialize**.
 Undefined behavior can crash your program at the worst possible moment, while it was running fine previously.
 It cannot be stressed enough: avoid undefined behavior at all cost.
-```
+~~~~
 
 ## Arithmetic Operations
 

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -32,13 +32,13 @@ int tomatoes{80};
 int potatoes = 40;
 ```
 
-```exercism/caution
+~~~~exercism/caution
 C++ does allow using uninitialized variables.
 Until the variable is deliberately set, it is undefined and might contain anything.
 To avoid used-before-set errors and undefined behavior it is adviseable to **always initialize**.
 Undefined behavior can crash your program at the worst possible moment, while it was running fine previously.
 It cannot be stressed enough: avoid undefined behavior at all cost.
-```
+~~~~
 
 ### Arithmetic Operations
 

--- a/exercises/practice/binary-search/.approaches/while-with-if-statements/content.md
+++ b/exercises/practice/binary-search/.approaches/while-with-if-statements/content.md
@@ -49,11 +49,11 @@ If the element at the index of the middle value matches the value being searched
 
 If the first `if` statement does not return, then another `if` statement is used to check the element.
 
-```exercism/note
+~~~~exercism/note
 Note that if an `if` statement can return, it does not need to be followed by an `else if ` or an `else`.
 If the statement returns, then control flow will leave the function.
 If the statement does not return, control will fall through to the next statement anyway.
-```
+~~~~
 
 If the element at the index of the middle value is less than the value being searched for, then `left` is set to the middle value
 plus one so that the next iteration will look for higher numbers.

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -13,7 +13,7 @@ Then we can use metric system prefixes for writing large numbers of seconds in m
 - Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
 - And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
 
-```exercism/note
+~~~~exercism/note
 If we ever colonize Mars or some other planet, measuring time is going to get even messier.
 If someone says "year" do they mean a year on Earth or a year on Mars?
 
@@ -21,4 +21,4 @@ The idea for this exercise came from the science fiction novel ["A Deepness in t
 In it the author uses the metric system as the basis for time measurements.
 
 [vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
-```
+~~~~

--- a/exercises/practice/pangram/.docs/introduction.md
+++ b/exercises/practice/pangram/.docs/introduction.md
@@ -7,10 +7,10 @@ To give a comprehensive sense of the font, the random sentences should use **all
 They're running a competition to get suggestions for sentences that they can use.
 You're in charge of checking the submissions to see if they are valid.
 
-```exercism/note
+~~~~exercism/note
 Pangram comes from Greek, παν γράμμα, pan gramma, which means "every letter".
 
 The best known English pangram is:
 
 > The quick brown fox jumps over the lazy dog.
-```
+~~~~


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705