### PR TITLE
Clarify instructions for anagram exercise

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -6,7 +6,7 @@ A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop
 Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
 
 The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
-Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp` because it's the same word.
 The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
 Words in the anagram set should have the same letter case as in the candidate set.
 


### PR DESCRIPTION
One of the examples in current instructions for anagram exercise (StoP is not an anagram of sTOp) is counter-intuitive and confusing without explanation. This commit clarifies said example by explaining why exactly it is not an anagram.