### PR TITLE
`int idx` --> `size_t idx` to prevent integer overflow

### DIFF
--- a/exercises/practice/sieve/.approaches/introduction.md
+++ b/exercises/practice/sieve/.approaches/introduction.md
@@ -31,10 +31,10 @@ namespace sieve {
 		std::vector<int> primes;
 		primes.reserve(limit / 2);
     
-		for (int number = 2; number <= limit; number++) {
+		for (long long number = 2; number <= limit; number++) {
 			if (!composite[number]) {
 				primes.emplace_back(number);
-				for(std::size_t idx = number * number; idx <= limit; idx +=number)
+				for(long long idx = number * number; idx <= limit; idx +=number)
 					composite[idx] = true;
 			}
 		}

--- a/exercises/practice/sieve/.approaches/introduction.md
+++ b/exercises/practice/sieve/.approaches/introduction.md
@@ -34,7 +34,7 @@ namespace sieve {
 		for (int number = 2; number <= limit; number++) {
 			if (!composite[number]) {
 				primes.emplace_back(number);
-				for(size_t idx = number * number; idx <= limit; idx +=number)
+				for(std::size_t idx = number * number; idx <= limit; idx +=number)
 					composite[idx] = true;
 			}
 		}

--- a/exercises/practice/sieve/.approaches/introduction.md
+++ b/exercises/practice/sieve/.approaches/introduction.md
@@ -34,7 +34,7 @@ namespace sieve {
 		for (int number = 2; number <= limit; number++) {
 			if (!composite[number]) {
 				primes.emplace_back(number);
-				for(int idx = number * number; idx <= limit; idx +=number)
+				for(size_t idx = number * number; idx <= limit; idx +=number)
 					composite[idx] = true;
 			}
 		}


### PR DESCRIPTION
```
for(int idx = number * number; idx <= limit; idx +=number)
	composite[idx] = true;
```
This code can be integer overflow if the limit > sqrt(maxInt). 
--> Then it leads to wrongly admit that idx <= limit. 
--> Then it leads to an out of bounds access at `composite[idx] = true` then it leads to **Segmentation Fault** (for example, when you set limit = 47000).