### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   linux-latest:
     name: Linux Latest Config
     needs: [linux-min]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         compiler: [clang++, g++]
@@ -62,7 +62,7 @@ jobs:
   windows:
     name: Windows
     needs: [linux-min]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     - name: Run Tests

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   format:
     name: "Format C++ code"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/format') || contains(github.event.comment.body, '/clang-format'))
     steps:
       - name: "Checkout code"

--- a/.github/workflows/hello-world.yml
+++ b/.github/workflows/hello-world.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   hello-world-fails:
     name: Hello World Fails
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Check Hello World Fails

--- a/.github/workflows/verify-code-formatting.yml
+++ b/.github/workflows/verify-code-formatting.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   verify-code-formatting:
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-22.04]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.