### PR TITLE
Sync hamming tests to problem-description data (#775)

### DIFF
--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
@@ -19,12 +26,42 @@ description = "long different strands"
 
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
+include = false
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
 
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
+include = false
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
+include = false
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+include = false
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
 
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
+include = false
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+include = false
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hamming/hamming_test.cpp
+++ b/exercises/practice/hamming/hamming_test.cpp
@@ -6,49 +6,49 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("no_difference_between_identical_strands")
+TEST_CASE("single letter identical strands", "[hamming][54681314-eee2-439a-9db0-b0636c656156]")
 {
     REQUIRE(0 == hamming::compute("A", "A"));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("complete_hamming_distance_for_single_nucleotide_strand")
+TEST_CASE("empty strands", "[hamming][f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]")
 {
-    REQUIRE(1 == hamming::compute("A", "G"));
+    REQUIRE(0 == hamming::compute("", ""));
 }
 
-TEST_CASE("complete_hamming_distance_for_small_strand")
+TEST_CASE("single letter different strands", "[hamming][294479a3-a4c8-478f-8d63-6209815a827b]")
 {
-    REQUIRE(2 == hamming::compute("AG", "CT"));
+    REQUIRE(1 == hamming::compute("G", "T"));
 }
 
-TEST_CASE("small_hamming_distance")
+TEST_CASE("long identical strands", "[hamming][9aed5f34-5693-4344-9b31-40c692fb5592]")
 {
-    REQUIRE(1 == hamming::compute("AT", "CT"));
+    REQUIRE(0 == hamming::compute("GGACTGAAATCTG", "GGACTGAAATCTG"));
 }
 
-TEST_CASE("small_hamming_distance_in_longer_strand")
-{
-    REQUIRE(1 == hamming::compute("GGACG", "GGTCG"));
-}
-
-TEST_CASE("domain_error_when_first_string_is_longer")
-{
-    REQUIRE_THROWS_AS(hamming::compute("AAAG", "AAA"), std::domain_error);
-}
-
-TEST_CASE("domain_error_when_second_string_is_longer")
-{
-    REQUIRE_THROWS_AS(hamming::compute("AAA", "AAAG"), std::domain_error);
-}
-
-TEST_CASE("large_hamming_distance")
-{
-    REQUIRE(4 == hamming::compute("GATACA", "GCATAA"));
-}
-
-TEST_CASE("hamming_distance_in_very_long_strand")
+TEST_CASE("long different strands", "[hamming][cd2273a5-c576-46c8-a52b-dee251c3e6e5]")
 {
     REQUIRE(9 == hamming::compute("GGACGGATTCTG", "AGGACGGATTCT"));
+}
+
+TEST_CASE("disallow first strand longer", "[hamming][b9228bb1-465f-4141-b40f-1f99812de5a8]")
+{
+    REQUIRE_THROWS_AS(hamming::compute("AATG", "AAA"), std::domain_error);
+}
+
+TEST_CASE("disallow second strand longer", "[hamming][dab38838-26bb-4fff-acbe-3b0a9bfeba2d]")
+{
+    REQUIRE_THROWS_AS(hamming::compute("ATA", "AGTG"), std::domain_error);
+}
+
+TEST_CASE("disallow empty first strand", "[hamming][b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]")
+{
+    REQUIRE_THROWS_AS(hamming::compute("", "G"), std::domain_error);
+}
+
+TEST_CASE("disallow empty second strand", "[hamming][9ab9262f-3521-4191-81f5-0ed184a5aa89]")
+{
+    REQUIRE_THROWS_AS(hamming::compute("G", ""), std::domain_error);
 }
 #endif


### PR DESCRIPTION
As discussed in #784, I was also confused about the `include = false` lines. The way I understand it, in `canonical-data.json` test cases are updated by adding a new version and a `reimplements` field that references the old version in the file. The old version is left untouched. I can imagine this is done to better be able to follow the edit history. But this also means that obsolete tests should _not_ be part of the implementation. So that is what I have done here.