### PR TITLE
Sync `armstrong-numbers`

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,30 +1,45 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
-description = "Single digit numbers are Armstrong numbers"
+description = "Single-digit numbers are Armstrong numbers"
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
-description = "There are no 2 digit Armstrong numbers"
+description = "There are no two-digit Armstrong numbers"
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
-description = "Three digit number that is an Armstrong number"
+description = "Three-digit number that is an Armstrong number"
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
-description = "Three digit number that is not an Armstrong number"
+description = "Three-digit number that is not an Armstrong number"
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
-description = "Four digit number that is an Armstrong number"
+description = "Four-digit number that is an Armstrong number"
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
-description = "Four digit number that is not an Armstrong number"
+description = "Four-digit number that is not an Armstrong number"
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
-description = "Seven digit number that is an Armstrong number"
+description = "Seven-digit number that is an Armstrong number"
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
-description = "Seven digit number that is not an Armstrong number"
+description = "Seven-digit number that is not an Armstrong number"
+
+[5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
+description = "Armstrong number containing seven zeroes"
+include = false
+
+[12ffbf10-307a-434e-b4ad-c925680e1dd4]
+description = "The largest and last Armstrong number"
+include = false


### PR DESCRIPTION
There are two new test cases that use big integers. They are not appropriate for standard C++, so they are not included.