### PR TITLE
Fix the tests for Catch2-v2 and Catch2-v3

### DIFF
--- a/exercises/practice/dnd-character/dnd_character_test.cpp
+++ b/exercises/practice/dnd-character/dnd_character_test.cpp
@@ -7,8 +7,11 @@
 
 #include <sstream>
 
+using namespace Catch;
+using namespace Catch::Matchers;
+
 template <typename T>
-class IsBetweenMatcher : public Catch::MatcherBase<T> {
+class IsBetweenMatcher : public MatcherBase<T> {
     T m_begin, m_end;
 public:
     IsBetweenMatcher(T begin, T end) :


### PR DESCRIPTION
Catch2-v3 did change the namespace for the `MatcherBase`.  
This patch aims to support both Catch2 v2 and v3.
But in the long run we should move to v3 locally and on the test runner.