### PR TITLE
fix: make matcher for catch2 v2 and v3 compatible

### DIFF
--- a/exercises/practice/dnd-character/dnd_character_test.cpp
+++ b/exercises/practice/dnd-character/dnd_character_test.cpp
@@ -7,8 +7,11 @@
 
 #include <sstream>
 
+using namespace Catch;
+using namespace Catch::Matchers;
+
 template <typename T>
-class IsBetweenMatcher : public Catch::MatcherBase<T> {
+class IsBetweenMatcher : public MatcherBase<T> {
     T m_begin, m_end;
 public:
     IsBetweenMatcher(T begin, T end) :


### PR DESCRIPTION
Thanks to @siebenschlaefer for finding that fix and [oxe-b](https://forum.exercism.org/t/possible-bug-in-dnd-character/9957) for reporting.