### PR TITLE
tests: update crypto-square exercise

### DIFF
--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -9,7 +9,8 @@
     "KevinWMatthews",
     "kytrinyx",
     "patricksjackson",
-    "sjwarner"
+    "sjwarner",
+    "ahans"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -1,9 +1,19 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
+
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"

--- a/exercises/practice/crypto-square/crypto_square_test.cpp
+++ b/exercises/practice/crypto-square/crypto_square_test.cpp
@@ -5,82 +5,51 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("normalize_capitals")
-{
-    REQUIRE("hello" == crypto_square::cipher("Hello").normalize_plain_text());
-}
-
-#if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("normalize_spaces")
-{
-    REQUIRE("hithere" == crypto_square::cipher("Hi there").normalize_plain_text());
-}
-
-TEST_CASE("normalize_numbers")
-{
-    REQUIRE("123go" == crypto_square::cipher("1, 2, 3 GO!").normalize_plain_text());
-}
-
-TEST_CASE("plain_text_empty")
-{
-    const std::vector<std::string> expected{};
-
-    const auto actual = crypto_square::cipher("").plain_text_segments();
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("plain_text_4_characters")
-{
-    const std::vector<std::string> expected{"ab", "cd"};
-
-    const auto actual = crypto_square::cipher("Ab Cd").plain_text_segments();
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("plain_text_9_characters")
-{
-    const std::vector<std::string> expected{"thi", "sis", "fun"};
-
-    const auto actual = crypto_square::cipher("This is fun!").plain_text_segments();
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("plain_text_segments_from_phrase")
-{
-    const std::vector<std::string> expected{"ifmanwas", "meanttos", "tayonthe", "groundgo", "dwouldha", "vegivenu", "sroots"};
-
-    const auto actual = crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").plain_text_segments();
-
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("cipher_text_empty_phrase")
-{
-    REQUIRE("" == crypto_square::cipher("").cipher_text());
-}
-
-TEST_CASE("cipher_text_long_phrase")
-{
-    REQUIRE("imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau" ==
-        crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").cipher_text());
-}
-
-TEST_CASE("normalized_cipher_text_empty")
-{
+TEST_CASE("empty plaintext results in an empty ciphertext",
+          "[407c3837-9aa7-4111-ab63-ec54b58e8e9f]") {
     REQUIRE("" == crypto_square::cipher("").normalized_cipher_text());
 }
 
-TEST_CASE("normalized_cipher_text_fun")
-{
-    REQUIRE("tsf hiu isn" == crypto_square::cipher("This is fun!").normalized_cipher_text());
+#if defined(EXERCISM_RUN_ALL_TESTS)
+TEST_CASE("normalization results in empty plaintext",
+          "[aad04a25-b8bb-4304-888b-581bea8e0040]") {
+    REQUIRE("" ==
+            crypto_square::cipher("... --- ...").normalized_cipher_text());
 }
 
-TEST_CASE("normalized_cipher_text_long_phrase")
-{
+TEST_CASE("Lowercase", "[64131d65-6fd9-4f58-bdd8-4a2370fb481d]") {
+    REQUIRE("a" == crypto_square::cipher("A").normalized_cipher_text());
+}
+
+TEST_CASE("Remove spaces", "[63a4b0ed-1e3c-41ea-a999-f6f26ba447d6]") {
+    REQUIRE("b" == crypto_square::cipher("  b ").normalized_cipher_text());
+}
+
+TEST_CASE("Remove punctuation", "[1b5348a1-7893-44c1-8197-42d48d18756c]") {
+    REQUIRE("1" == crypto_square::cipher("@1,%!").normalized_cipher_text());
+}
+
+TEST_CASE("9 character plaintext results in 3 chunks of 3 characters",
+          "[8574a1d3-4a08-4cec-a7c7-de93a164f41a]") {
+    REQUIRE("tsf hiu isn" ==
+            crypto_square::cipher("This is fun!").normalized_cipher_text());
+}
+
+TEST_CASE(
+    "8 character plaintext results in 3 chunks, the last one with a trailing "
+    "space",
+    "[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]") {
+    REQUIRE("clu hlt io " ==
+            crypto_square::cipher("Chill out.").normalized_cipher_text());
+}
+
+TEST_CASE(
+    "54 character plaintext results in 7 chunks, the last two with trailing "
+    "spaces",
+    "[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]") {
     REQUIRE("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau " ==
-        crypto_square::cipher("If man was meant to stay on the ground, god would have given us roots.").normalized_cipher_text());
+            crypto_square::cipher("If man was meant to stay on the ground, god "
+                                  "would have given us roots.")
+                .normalized_cipher_text());
 }
 #endif

--- a/exercises/practice/crypto-square/crypto_square_test.cpp
+++ b/exercises/practice/crypto-square/crypto_square_test.cpp
@@ -36,8 +36,9 @@ TEST_CASE("9 character plaintext results in 3 chunks of 3 characters",
 }
 
 TEST_CASE(
-    "8 character plaintext results in 3 chunks, the last one with a trailing "
-    "space",
+    // clang-format off
+    "8 character plaintext results in 3 chunks, the last one with a trailing space",
+    // clang-format on
     "[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]") {
     REQUIRE("clu hlt io " ==
             crypto_square::cipher("Chill out.").normalized_cipher_text());


### PR DESCRIPTION
The original tests expected that the implementation also exposes intermediate steps, such as the normalized plaintext. I think this unnecessarily restricts the implementation and is also not reflected in the canonical data. So now I changed all tests to exactly correspond to the canonical data. Let me know if that's not what I should have done. I can also just add the one extra test case. But adding the test UUIDs would be a bit hard then ...