### PR TITLE
fix: missing assertions in parallel-letter-frequency test

### DIFF
--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -5,7 +5,7 @@
 There are several ways how to achieve parallelism in C++.
 Exercism's online runner supports C++17, so you can use execution policies from the [algorithms library][algorithm].
 Another option is manually managing [threads][thread].
-However, note that spawning a thread is quite expensive (using a thread [pool][pool] would help).
+However, note that spawning a thread is quite expensive (using a [thread pool][pool] would help).
 
 When working locally, you can of course use whatever you want.
 However, a solution using non-standard libraries will most probably not work with the Exercism online runner.

--- a/exercises/practice/parallel-letter-frequency/.meta/example.cpp
+++ b/exercises/practice/parallel-letter-frequency/.meta/example.cpp
@@ -18,7 +18,11 @@ namespace {
 [[nodiscard]] std::unordered_map<char, size_t> frequency(
     std::string_view const text) {
     std::unordered_map<char, size_t> freq;
-    for (unsigned char c : text) freq[std::tolower(c)] += 1;
+    for (unsigned char c : text) {
+        if (std::isalpha(c)) {
+            freq[std::tolower(c)] += 1;
+        }
+    }
     return freq;
 }
 

--- a/exercises/practice/parallel-letter-frequency/parallel_letter_frequency.cpp
+++ b/exercises/practice/parallel-letter-frequency/parallel_letter_frequency.cpp
@@ -1,2 +1,5 @@
 #include "parallel_letter_frequency.h"
 
+namespace parallel_letter_frequency {
+
+}

--- a/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.cpp
+++ b/exercises/practice/parallel-letter-frequency/parallel_letter_frequency_test.cpp
@@ -80,6 +80,7 @@ TEST_CASE("ignore whitespace",
         "\n",
     };
     auto freqs = parallel_letter_frequency::frequency(texts);
+    CHECK(freqs.empty());
 }
 
 TEST_CASE("ignore punctuation",
@@ -88,6 +89,7 @@ TEST_CASE("ignore punctuation",
         "!", "?", ";", ",", ".",
     };
     auto freqs = parallel_letter_frequency::frequency(texts);
+    CHECK(freqs.empty());
 }
 
 TEST_CASE("ignore numbers",
@@ -96,6 +98,7 @@ TEST_CASE("ignore numbers",
         "1", "2", "3", "4", "5", "6", "7", "8", "9",
     };
     auto freqs = parallel_letter_frequency::frequency(texts);
+    CHECK(freqs.empty());
 }
 
 TEST_CASE(


### PR DESCRIPTION
Also fix the "thread pool" link in `instructions.append.md`.