### PR TITLE
crypto-square: Fix formatting of test code

### DIFF
--- a/exercises/practice/crypto-square/crypto_square_test.cpp
+++ b/exercises/practice/crypto-square/crypto_square_test.cpp
@@ -5,14 +5,12 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("empty plaintext results in an empty ciphertext",
-          "[407c3837-9aa7-4111-ab63-ec54b58e8e9f]") {
+TEST_CASE("empty plaintext results in an empty ciphertext", "[407c3837-9aa7-4111-ab63-ec54b58e8e9f]") {
     REQUIRE("" == crypto_square::cipher("").normalized_cipher_text());
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("normalization results in empty plaintext",
-          "[aad04a25-b8bb-4304-888b-581bea8e0040]") {
+TEST_CASE("normalization results in empty plaintext", "[aad04a25-b8bb-4304-888b-581bea8e0040]") {
     REQUIRE("" ==
             crypto_square::cipher("... --- ...").normalized_cipher_text());
 }
@@ -35,22 +33,18 @@ TEST_CASE("9 character plaintext results in 3 chunks of 3 characters",
             crypto_square::cipher("This is fun!").normalized_cipher_text());
 }
 
-TEST_CASE(
-    // clang-format off
-    "8 character plaintext results in 3 chunks, the last one with a trailing space",
-    // clang-format on
-    "[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]") {
+// clang-format off
+TEST_CASE("8 character plaintext results in 3 chunks, the last one with a trailing space", "[a65d3fa1-9e09-43f9-bcec-7a672aec3eae]") {
     REQUIRE("clu hlt io " ==
             crypto_square::cipher("Chill out.").normalized_cipher_text());
 }
 
-TEST_CASE(
-    "54 character plaintext results in 7 chunks, the last two with trailing "
-    "spaces",
-    "[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]") {
+TEST_CASE("54 character plaintext results in 7 chunks, the last two with trailing spaces", "[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]") {
     REQUIRE("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau " ==
             crypto_square::cipher("If man was meant to stay on the ground, god "
                                   "would have given us roots.")
                 .normalized_cipher_text());
 }
+// clang-format on
+
 #endif


### PR DESCRIPTION
Currently the test runner cannot parse the tests, see https://forum.exercism.org/t/crypto-square-works-on-my-machine-an-error-occured-when-submitted/10303/9

@vaeng Feel free to modify this PR as you like.