### PR TITLE
Update about.md small typo

### DIFF
--- a/concepts/functions/about.md
+++ b/concepts/functions/about.md
@@ -66,7 +66,7 @@ class Stubborn {
         response = reply;
     }
     string answer(const string& question) const {
-        if (question.lenghth() == 0) { return "";}
+        if (question.length() == 0) { return "";}
         return response;
     }
     private:


### PR DESCRIPTION
Small typo where length was spelled lenghth instead of length.