### PR TITLE
Added new test for grade school exercise

### DIFF
--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -12,7 +12,8 @@
     "kytrinyx",
     "objarni",
     "patricksjackson",
-    "siebenschlaefer"
+    "siebenschlaefer",
+    "thgnommy"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/grade-school/.meta/example.cpp
+++ b/exercises/practice/grade-school/.meta/example.cpp
@@ -8,6 +8,11 @@ namespace grade_school
 
 void school::add(string const& name, int grade)
 {
+
+    if (studentNameAlreadyExist(name)) {
+        return;
+    }
+
     vector<string>& grade_roster = roster_[grade];
     auto it = lower_bound(grade_roster.begin(), grade_roster.end(), name);
     grade_roster.insert(it, name);
@@ -17,6 +22,15 @@ vector<string> school::grade(int grade) const
 {
     auto it = roster_.find(grade);
     return (it != roster_.end()) ? it->second : vector<string>{};
+}
+
+bool school::studentNameAlreadyExist(const std::string& name) const {
+    int result{};
+    for (const auto& element : roster_) {
+        result +=
+            std::count(element.second.cbegin(), element.second.cend(), name);
+    }
+    return result;
 }
 
 }

--- a/exercises/practice/grade-school/.meta/example.h
+++ b/exercises/practice/grade-school/.meta/example.h
@@ -19,6 +19,8 @@ public:
 
     std::vector<std::string> grade(int grade) const;
 
+    bool school::studentNameAlreadyExist(const std::string& name) const;
+
 private:
     std::map<int, std::vector<std::string>> roster_;
 };

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -22,3 +22,6 @@ description = "Grade returns the students in that grade in alphabetical order"
 
 [5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
 description = "Grade returns an empty list if there are no students in that grade"
+
+[5cb2d402-bc57-4823-afb0-4bf42bf6cf06]
+description = "Adding students with the same name is not allowed"

--- a/exercises/practice/grade-school/grade_school_test.cpp
+++ b/exercises/practice/grade-school/grade_school_test.cpp
@@ -97,4 +97,18 @@ TEST_CASE("checking_a_grade_should_not_change_the_roster")
     REQUIRE(school_.roster().empty());
 }
 
+TEST_CASE("adding_students_with_the_same_name_is_not_allowed") 
+{
+    const grade_school::school school_{};
+    school_.add("Karina", 5);
+    school_.add("Karina", 3);
+    school_.add("Karina", 3);
+    school_.add("Thomas", 4);
+
+    const auto actual = school_.roster();
+    const map<int, vector<string>> expected{{5, {"Karina"}}, {4, {"Thomas"}}};
+
+    REQUIRE(expected == actual);
+}
+
 #endif


### PR DESCRIPTION
Hello! 

After finishing the exercise [grade-school](https://exercism.org/tracks/cpp/exercises/grade-school), I noticed that a test is missing when looking at the instructions. So, I added it.

From the instructions:
> Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster. In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.

Please tell me if I missed something or if there is room for improvement.

Thank you!