### PR TITLE
docs: N is not existing variable

### DIFF
--- a/exercises/concept/interest-is-interesting/.docs/introduction.md
+++ b/exercises/concept/interest-is-interesting/.docs/introduction.md
@@ -84,7 +84,7 @@ In contrast, the keyword `continue` only stops the execution of the current iter
 ```cpp
 int equal_sum{0};
 for (int i{1}; i < 7; ++i) {
-  if  (n%2 == 1) {
+  if  (i%2 == 1) {
     continue;
   }
   equal_sum += i;


### PR DESCRIPTION
Fixing this also on the documentation of the exercise, This should be pointing to `i`.
Previous PR was fixing it on the learning section but it seems it is also on the exercise itself