### PR TITLE
feat: add negative midnight test case for clock exercise

### DIFF
--- a/exercises/practice/clock/clock_test.cpp
+++ b/exercises/practice/clock/clock_test.cpp
@@ -19,6 +19,7 @@ vector<timeTest> timeCases = {
     {8, 0, "08:00",        "on the hour"},
     {11, 9, "11:09",       "past the hour"},
     {24, 0, "00:00",       "midnight is zero hours"},
+    {-24, 0, "00:00",      "negative midnight is zero hours"},
     {25, 0, "01:00",       "hour rolls over"},
     {100, 0, "04:00",      "hour rolls over continuously"},
     {1, 60, "02:00",       "sixty minutes is next hour"},


### PR DESCRIPTION
The test did not include situations where the final hours are equal to `-24` and the minutes are equal to `0`. This situation should also return `00:00`. I added the test case `{-24, 0, "00:00", "negative midnight is zero hours"}` to ensure this is now checked. Both `24:00` and `-24:00` should return the same result.
