### PR TITLE
Hit requirement untested

### DIFF
--- a/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
+++ b/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
@@ -32,7 +32,9 @@ TEST_CASE("Alien is always hit", "[task_2]") {
     REQUIRE(alien.hit());
 }
 
-TEST_CASE("Alien is alive while health is greater than 0 and stays dead afterwards", "[task_3]") {
+TEST_CASE(
+    "Alien is alive while health is greater than 0 and stays dead afterwards",
+    "[task_3]") {
     Alien alien{2, 54};
     REQUIRE(alien.is_alive());
     alien.hit();

--- a/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
+++ b/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
@@ -43,6 +43,7 @@ TEST_CASE("Alien is alive while health is greater than 0 and stays dead afterwar
     REQUIRE(!alien.is_alive());
     alien.hit();
     REQUIRE(!alien.is_alive());
+    REQUIRE(alien.get_health() == 0);
 }
 
 TEST_CASE("Alien Teleports reports succesful", "[task_4]") {


### PR DESCRIPTION
There is a requirement for exercise ellens-alien-game's hit() method which states: "Make sure that the health points do not drop below zero." Adding a "get_health() == 0" at the end of the hit test now tests whether this is the case.