### PR TITLE
fix(say): remove misleading comment

### DIFF
--- a/exercises/practice/say/say_test.cpp
+++ b/exercises/practice/say/say_test.cpp
@@ -5,11 +5,6 @@
 #include "test/catch.hpp"
 #endif
 
-/*
-An 'error' object is used as expected value to indicate that the
-input value is out of the range described in the exercise.
-*/
-
 TEST_CASE("zero", "[5d22a120-ba0c-428c-bd25-8682235d83e8]") {
     REQUIRE("zero" == say::in_english(0));
 }


### PR DESCRIPTION
I think a student could be very confused by this comment when we expect them to throw in case of an error. This comment is verbatim copy from the [problem specification](https://github.com/exercism/problem-specifications/blob/main/exercises/say/canonical-data.json#L4). At the very least, it should be reworded to make clear that we expect an exception, but I think it's best removed.

[no important files changed]