### PR TITLE
Sync and sort roman-numeral tests

### DIFF
--- a/exercises/practice/roman-numerals/.meta/example.cpp
+++ b/exercises/practice/roman-numerals/.meta/example.cpp
@@ -1,35 +1,23 @@
 #include "roman_numerals.h"
 
-namespace
-{
+namespace {
 
-struct digit_values
-{
+struct digit_values {
     char numeral;
     int value;
 };
 
-const digit_values roman_numerals[] =
-{
-    { 'M', 1000 },
-    { 'D', 500 },
-    { 'C', 100 },
-    { 'L', 50 },
-    { 'X', 10 },
-    { 'V', 5 },
-    { 'I', 1 }
-};
+const digit_values roman_numerals[] = {{'M', 1000}, {'D', 500}, {'C', 100},
+                                       {'L', 50},   {'X', 10},  {'V', 5},
+                                       {'I', 1}};
 
-class converter
-{
-public:
-    converter(int n)
-        : n_(n)
-    {}
+class converter {
+   public:
+    converter(int n) : n_(n) {}
 
     std::string convert();
 
-private:
+   private:
     void thousands();
     void hundreds();
     void tens();
@@ -42,8 +30,7 @@ private:
     std::string result_;
 };
 
-std::string converter::convert()
-{
+std::string converter::convert() {
     thousands();
     hundreds();
     tens();
@@ -51,28 +38,15 @@ std::string converter::convert()
     return result_;
 }
 
-void converter::thousands()
-{
-    place(0);
-}
+void converter::thousands() { place(0); }
 
-void converter::hundreds()
-{
-    place(2);
-}
+void converter::hundreds() { place(2); }
 
-void converter::tens()
-{
-    place(4);
-}
+void converter::tens() { place(4); }
 
-void converter::ones()
-{
-    result_ += std::string(n_, 'I');
-}
+void converter::ones() { result_ += std::string(n_, 'I'); }
 
-void converter::place(int place)
-{
+void converter::place(int place) {
     const int tenth_place = place + 2;
     place_numeral(place);
     place_numeral_penultimate(place, tenth_place);
@@ -81,17 +55,16 @@ void converter::place(int place)
     place_numeral_penultimate(half_place, tenth_place);
 }
 
-void converter::place_numeral(int place)
-{
+void converter::place_numeral(int place) {
     while (n_ >= roman_numerals[place].value) {
         result_ += roman_numerals[place].numeral;
         n_ -= roman_numerals[place].value;
     }
 }
 
-void converter::place_numeral_penultimate(int place, int penultimate_place)
-{
-    const int amount = roman_numerals[place].value - roman_numerals[penultimate_place].value;
+void converter::place_numeral_penultimate(int place, int penultimate_place) {
+    const int amount =
+        roman_numerals[place].value - roman_numerals[penultimate_place].value;
     if (n_ >= amount) {
         result_ += roman_numerals[penultimate_place].numeral;
         result_ += roman_numerals[place].numeral;
@@ -99,9 +72,6 @@ void converter::place_numeral_penultimate(int place, int penultimate_place)
     }
 }
 
-}
+}  // namespace
 
-std::string roman_numerals::convert(int n)
-{
-    return converter(n).convert();
-}
+std::string roman_numerals::convert(int n) { return converter(n).convert(); }

--- a/exercises/practice/roman-numerals/.meta/example.h
+++ b/exercises/practice/roman-numerals/.meta/example.h
@@ -3,8 +3,7 @@
 
 #include <string>
 
-namespace roman_numerals
-{
+namespace roman_numerals {
 
 std::string convert(int n);
 

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -30,6 +30,9 @@ description = "6 is VI"
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9 is IX"
 
+[6d1d82d5-bf3e-48af-9139-87d7165ed509]
+description = "16 is XVI"
+
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "27 is XXVII"
 
@@ -42,6 +45,9 @@ description = "49 is XLIX"
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "59 is LIX"
 
+[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
+description = "66 is LXVI"
+
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "93 is XCIII"
 
@@ -51,11 +57,17 @@ description = "141 is CXLI"
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "163 is CLXIII"
 
+[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
+description = "166 is CLXVI"
+
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "402 is CDII"
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "575 is DLXXV"
+
+[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
+description = "666 is DCLXVI"
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "911 is CMXI"
@@ -63,26 +75,17 @@ description = "911 is CMXI"
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1024 is MXXIV"
 
-[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
-description = "3000 is MMM"
-
-[6d1d82d5-bf3e-48af-9139-87d7165ed509]
-description = "16 is XVI"
-
-[4465ffd5-34dc-44f3-ada5-56f5007b6dad]
-description = "66 is LXVI"
-
-[902ad132-0b4d-40e3-8597-ba5ed611dd8d]
-description = "166 is CLXVI"
-
-[dacb84b9-ea1c-4a61-acbb-ce6b36674906]
-description = "666 is DCLXVI"
-
 [efbe1d6a-9f98-4eb5-82bc-72753e3ac328]
 description = "1666 is MDCLXVI"
 
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is MMM"
+
 [3bc4b41c-c2e6-49d9-9142-420691504336]
 description = "3001 is MMMI"
+
+[2f89cad7-73f6-4d1b-857b-0ef531f68b7e]
+description = "3888 is MMMDCCCLXXXVIII"
 
 [4e18e96b-5fbb-43df-a91b-9cb511fe0856]
 description = "3999 is MMMCMXCIX"

--- a/exercises/practice/roman-numerals/roman_numerals.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals.cpp
@@ -1,5 +1,3 @@
 #include "roman_numerals.h"
 
-namespace roman_numerals {
-
-}  // namespace roman_numerals
+namespace roman_numerals {}  // namespace roman_numerals

--- a/exercises/practice/roman-numerals/roman_numerals.h
+++ b/exercises/practice/roman-numerals/roman_numerals.h
@@ -1,8 +1,6 @@
 #if !defined(ROMAN_NUMERALS_H)
 #define ROMAN_NUMERALS_H
 
-namespace roman_numerals {
+namespace roman_numerals {}  // namespace roman_numerals
 
-}  // namespace roman_numerals
-
-#endif // ROMAN_NUMERALS_H
+#endif  // ROMAN_NUMERALS_H

--- a/exercises/practice/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals_test.cpp
@@ -34,6 +34,10 @@ TEST_CASE("9_is_ix")
 {
     REQUIRE("IX" == roman_numerals::convert(9));
 }
+TEST_CASE("16_is_xvi")
+{
+    REQUIRE("XVI" == roman_numerals::convert(16));
+}
 TEST_CASE("27_is_xxvii")
 {
     REQUIRE("XXVII" == roman_numerals::convert(27));
@@ -50,6 +54,10 @@ TEST_CASE("59_is_lix")
 {
     REQUIRE("LIX" == roman_numerals::convert(59));
 }
+TEST_CASE("66_is_lxvi")
+{
+    REQUIRE("LXVI" == roman_numerals::convert(66));
+}
 TEST_CASE("93_is_xciii")
 {
     REQUIRE("XCIII" == roman_numerals::convert(93));
@@ -62,6 +70,10 @@ TEST_CASE("163_is_clxiii")
 {
     REQUIRE("CLXIII" == roman_numerals::convert(163));
 }
+TEST_CASE("166_is_clxvi")
+{
+    REQUIRE("CLXVI" == roman_numerals::convert(166));
+}
 TEST_CASE("402_is_cdii")
 {
     REQUIRE("CDII" == roman_numerals::convert(402));
@@ -69,6 +81,10 @@ TEST_CASE("402_is_cdii")
 TEST_CASE("575_is_dlxxv")
 {
     REQUIRE("DLXXV" == roman_numerals::convert(575));
+}
+TEST_CASE("666_is_dclxvi")
+{
+    REQUIRE("DCLXVI" == roman_numerals::convert(666));
 }
 TEST_CASE("911_is_cmxi")
 {
@@ -78,33 +94,21 @@ TEST_CASE("1024_is_mxxiv")
 {
     REQUIRE("MXXIV" == roman_numerals::convert(1024));
 }
-TEST_CASE("3000_is_mmm")
-{
-    REQUIRE("MMM" == roman_numerals::convert(3000));
-}
-TEST_CASE("16_is_xvi")
-{
-    REQUIRE("XVI" == roman_numerals::convert(16));
-}
-TEST_CASE("66_is_lxvi")
-{
-    REQUIRE("LXVI" == roman_numerals::convert(66));
-}
-TEST_CASE("166_is_clxvi")
-{
-    REQUIRE("CLXVI" == roman_numerals::convert(166));
-}
-TEST_CASE("666_is_dclxvi")
-{
-    REQUIRE("DCLXVI" == roman_numerals::convert(666));
-}
 TEST_CASE("1666_is_mdclxvi")
 {
     REQUIRE("MDCLXVI" == roman_numerals::convert(1666));
 }
+TEST_CASE("3000_is_mmm")
+{
+    REQUIRE("MMM" == roman_numerals::convert(3000));
+}
 TEST_CASE("3001_is_mmmi")
 {
     REQUIRE("MMMI" == roman_numerals::convert(3001));
+}
+TEST_CASE("3888_is_mmmdccclxxxviii")
+{
+    REQUIRE("MMMDCCCLXXXVIII" == roman_numerals::convert(3888));
 }
 TEST_CASE("3999_is_mmmcmxcix")
 {

--- a/exercises/practice/roman-numerals/roman_numerals_test.cpp
+++ b/exercises/practice/roman-numerals/roman_numerals_test.cpp
@@ -5,113 +5,44 @@
 #include "test/catch.hpp"
 #endif
 
-TEST_CASE("1_is_i")
-{
-    REQUIRE("I" == roman_numerals::convert(1));
-}
+TEST_CASE("1_is_i") { REQUIRE("I" == roman_numerals::convert(1)); }
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("2_is_ii")
-{
-    REQUIRE("II" == roman_numerals::convert(2));
-}
-TEST_CASE("3_is_iii")
-{
-    REQUIRE("III" == roman_numerals::convert(3));
-}
-TEST_CASE("4_is_iv")
-{
-    REQUIRE("IV" == roman_numerals::convert(4));
-}
-TEST_CASE("5_is_v")
-{
-    REQUIRE("V" == roman_numerals::convert(5));
-}
-TEST_CASE("6_is_vi")
-{
-    REQUIRE("VI" == roman_numerals::convert(6));
-}
-TEST_CASE("9_is_ix")
-{
-    REQUIRE("IX" == roman_numerals::convert(9));
-}
-TEST_CASE("16_is_xvi")
-{
-    REQUIRE("XVI" == roman_numerals::convert(16));
-}
-TEST_CASE("27_is_xxvii")
-{
-    REQUIRE("XXVII" == roman_numerals::convert(27));
-}
-TEST_CASE("48_is_xlviii")
-{
-    REQUIRE("XLVIII" == roman_numerals::convert(48));
-}
-TEST_CASE("49_is_xlix")
-{
-    REQUIRE("XLIX" == roman_numerals::convert(49));
-}
-TEST_CASE("59_is_lix")
-{
-    REQUIRE("LIX" == roman_numerals::convert(59));
-}
-TEST_CASE("66_is_lxvi")
-{
-    REQUIRE("LXVI" == roman_numerals::convert(66));
-}
-TEST_CASE("93_is_xciii")
-{
-    REQUIRE("XCIII" == roman_numerals::convert(93));
-}
-TEST_CASE("141_is_cxli")
-{
-    REQUIRE("CXLI" == roman_numerals::convert(141));
-}
-TEST_CASE("163_is_clxiii")
-{
+TEST_CASE("2_is_ii") { REQUIRE("II" == roman_numerals::convert(2)); }
+TEST_CASE("3_is_iii") { REQUIRE("III" == roman_numerals::convert(3)); }
+TEST_CASE("4_is_iv") { REQUIRE("IV" == roman_numerals::convert(4)); }
+TEST_CASE("5_is_v") { REQUIRE("V" == roman_numerals::convert(5)); }
+TEST_CASE("6_is_vi") { REQUIRE("VI" == roman_numerals::convert(6)); }
+TEST_CASE("9_is_ix") { REQUIRE("IX" == roman_numerals::convert(9)); }
+TEST_CASE("16_is_xvi") { REQUIRE("XVI" == roman_numerals::convert(16)); }
+TEST_CASE("27_is_xxvii") { REQUIRE("XXVII" == roman_numerals::convert(27)); }
+TEST_CASE("48_is_xlviii") { REQUIRE("XLVIII" == roman_numerals::convert(48)); }
+TEST_CASE("49_is_xlix") { REQUIRE("XLIX" == roman_numerals::convert(49)); }
+TEST_CASE("59_is_lix") { REQUIRE("LIX" == roman_numerals::convert(59)); }
+TEST_CASE("66_is_lxvi") { REQUIRE("LXVI" == roman_numerals::convert(66)); }
+TEST_CASE("93_is_xciii") { REQUIRE("XCIII" == roman_numerals::convert(93)); }
+TEST_CASE("141_is_cxli") { REQUIRE("CXLI" == roman_numerals::convert(141)); }
+TEST_CASE("163_is_clxiii") {
     REQUIRE("CLXIII" == roman_numerals::convert(163));
 }
-TEST_CASE("166_is_clxvi")
-{
-    REQUIRE("CLXVI" == roman_numerals::convert(166));
-}
-TEST_CASE("402_is_cdii")
-{
-    REQUIRE("CDII" == roman_numerals::convert(402));
-}
-TEST_CASE("575_is_dlxxv")
-{
-    REQUIRE("DLXXV" == roman_numerals::convert(575));
-}
-TEST_CASE("666_is_dclxvi")
-{
+TEST_CASE("166_is_clxvi") { REQUIRE("CLXVI" == roman_numerals::convert(166)); }
+TEST_CASE("402_is_cdii") { REQUIRE("CDII" == roman_numerals::convert(402)); }
+TEST_CASE("575_is_dlxxv") { REQUIRE("DLXXV" == roman_numerals::convert(575)); }
+TEST_CASE("666_is_dclxvi") {
     REQUIRE("DCLXVI" == roman_numerals::convert(666));
 }
-TEST_CASE("911_is_cmxi")
-{
-    REQUIRE("CMXI" == roman_numerals::convert(911));
-}
-TEST_CASE("1024_is_mxxiv")
-{
+TEST_CASE("911_is_cmxi") { REQUIRE("CMXI" == roman_numerals::convert(911)); }
+TEST_CASE("1024_is_mxxiv") {
     REQUIRE("MXXIV" == roman_numerals::convert(1024));
 }
-TEST_CASE("1666_is_mdclxvi")
-{
+TEST_CASE("1666_is_mdclxvi") {
     REQUIRE("MDCLXVI" == roman_numerals::convert(1666));
 }
-TEST_CASE("3000_is_mmm")
-{
-    REQUIRE("MMM" == roman_numerals::convert(3000));
-}
-TEST_CASE("3001_is_mmmi")
-{
-    REQUIRE("MMMI" == roman_numerals::convert(3001));
-}
-TEST_CASE("3888_is_mmmdccclxxxviii")
-{
+TEST_CASE("3000_is_mmm") { REQUIRE("MMM" == roman_numerals::convert(3000)); }
+TEST_CASE("3001_is_mmmi") { REQUIRE("MMMI" == roman_numerals::convert(3001)); }
+TEST_CASE("3888_is_mmmdccclxxxviii") {
     REQUIRE("MMMDCCCLXXXVIII" == roman_numerals::convert(3888));
 }
-TEST_CASE("3999_is_mmmcmxcix")
-{
+TEST_CASE("3999_is_mmmcmxcix") {
     REQUIRE("MMMCMXCIX" == roman_numerals::convert(3999));
 }
 #endif


### PR DESCRIPTION
I added the test for 3888. In the process of doing that, it appears the test order in tests.toml has since changed so I updated the the test suite order to reflect that