### PR TITLE
Update `grade-school` tests

### DIFF
--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,24 +1,86 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
-[6d0a30e4-1b4e-472e-8e20-c41702125667]
-description = "Adding a student adds them to the sorted roster"
-
-[233be705-dd58-4968-889d-fb3c7954c9cc]
-description = "Adding more student adds them to the sorted roster"
-
-[75a51579-d1d7-407c-a2f8-2166e984e8ab]
-description = "Adding students to different grades adds them to the same sorted roster"
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [a3f0fb58-f240-4723-8ddc-e644666b85cc]
-description = "Roster returns an empty list if there are no students enrolled"
+description = "Roster is empty when no student is added"
+
+[9337267f-7793-4b90-9b4a-8e3978408824]
+description = "Add a student"
+
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Student is added to the roster"
+
+[73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a]
+description = "Adding multiple students in the same grade in the roster"
+
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Multiple students in the same grade are added to the roster"
+
+[87c871c1-6bde-4413-9c44-73d59a259d83]
+description = "Cannot add student to same grade in the roster more than once"
+
+[c125dab7-2a53-492f-a99a-56ad511940d8]
+description = "A student can't be in two different grades"
+include = false
+
+[a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
+description = "A student can only be added to the same grade in the roster once"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[d7982c4f-1602-49f6-a651-620f2614243a]
+description = "Student not added to same grade in the roster more than once"
+reimplements = "a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1"
+
+[e70d5d8f-43a9-41fd-94a4-1ea0fa338056]
+description = "Adding students in multiple grades"
+
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Students in multiple grades are added to the roster"
+
+[7df542f1-57ce-433c-b249-ff77028ec479]
+description = "Cannot add same student to multiple grades in the roster"
+
+[6a03b61e-1211-4783-a3cc-fc7f773fba3f]
+description = "A student cannot be added to more than one grade in the sorted roster"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5]
+description = "Student not added to multiple grades in the roster"
+reimplements = "6a03b61e-1211-4783-a3cc-fc7f773fba3f"
+
+[d9af4f19-1ba1-48e7-94d0-dabda4e5aba6]
+description = "Students are sorted by grades in the roster"
+
+[d9fb5bea-f5aa-4524-9d61-c158d8906807]
+description = "Students are sorted by name in the roster"
 
 [180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
-description = "Student names with grades are displayed in the same sorted roster"
-
-[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
-description = "Grade returns the students in that grade in alphabetical order"
+description = "Students are sorted by grades and then by name in the roster"
 
 [5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
-description = "Grade returns an empty list if there are no students in that grade"
+description = "Grade is empty if no students in the roster"
+
+[1e0cf06b-26e0-4526-af2d-a2e2df6a51d6]
+description = "Grade is empty if no students in that grade"
+
+[2bfc697c-adf2-4b65-8d0f-c46e085f796e]
+description = "Student not added to same grade more than once"
+
+[66c8e141-68ab-4a04-a15a-c28bc07fe6b9]
+description = "Student not added to multiple grades"
+
+[c9c1fc2f-42e0-4d2c-b361-99271f03eda7]
+description = "Student not added to other grade for multiple grades"
+
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Students are sorted by name in a grade"

--- a/exercises/practice/grade-school/grade_school_test.cpp
+++ b/exercises/practice/grade-school/grade_school_test.cpp
@@ -8,93 +8,172 @@
 
 using namespace std;
 
-TEST_CASE("a_new_school_has_an_empty_roster")
-{
-    const grade_school::school school_{};
+TEST_CASE("Roster is empty when no student is added", "[a3f0fb58-f240-4723-8ddc-e644666b85cc]") {
+    const grade_school::school school_;
     REQUIRE(school_.roster().empty());
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-TEST_CASE("adding_a_student_adds_them_to_the_roster_for_the_given_grade")
-{
+
+TEST_CASE("Add a student", "[9337267f-7793-4b90-9b4a-8e3978408824]") {
     grade_school::school school_;
     school_.add("Aimee", 2);
-
-    const auto actual = school_.roster();
-
-    const map<int, vector<string>> expected{{2, {"Aimee"}}};
-    REQUIRE(expected == actual);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Aimee"}}});
 }
 
-TEST_CASE("adding_more_students_to_the_same_grade_adds_them_to_the_roster")
-{
+TEST_CASE("Student is added to the roster", "[6d0a30e4-1b4e-472e-8e20-c41702125667]") {
+    grade_school::school school_;
+    school_.add("Aimee", 2);
+    REQUIRE(school_.grade(2) == vector<string>{"Aimee"});
+}
+
+TEST_CASE("Adding multiple students in the same grade in the roster", "[73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a]") {
     grade_school::school school_;
     school_.add("Blair", 2);
     school_.add("James", 2);
     school_.add("Paul", 2);
-
-    const auto actual = school_.roster();
-
-    const map<int, vector<string>> expected{{2, {"Blair", "James", "Paul"}}};
-    REQUIRE(expected == actual);
+    REQUIRE(school_.grade(2) == vector<string>{"Blair", "James", "Paul"});
 }
 
-TEST_CASE("adding_students_to_different_grades_adds_them_to_the_roster")
-{
+TEST_CASE("Multiple students in the same grade are added to the roster", "[233be705-dd58-4968-889d-fb3c7954c9cc]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("Paul", 2);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Blair", "James", "Paul"}}});
+}
+
+TEST_CASE("Cannot add student to same grade in the roster more than once", "[87c871c1-6bde-4413-9c44-73d59a259d83]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 2);
+    school_.add("Paul", 2);
+    REQUIRE(school_.grade(2) == vector<string>{"Blair", "James", "Paul"});
+}
+
+TEST_CASE("Student not added to same grade in the roster more than once", "[d7982c4f-1602-49f6-a651-620f2614243a]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 2);
+    school_.add("Paul", 2);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Blair", "James", "Paul"}}});
+}
+
+TEST_CASE("Adding students in multiple grades", "[e70d5d8f-43a9-41fd-94a4-1ea0fa338056]") {
     grade_school::school school_;
     school_.add("Chelsea", 3);
     school_.add("Logan", 7);
-
-    const auto actual = school_.roster();
-
-    const map<int, vector<string>> expected{{3, {"Chelsea"}}, {7, {"Logan"}}};
-    REQUIRE(expected == actual);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{3, {"Chelsea"}}, {7, {"Logan"}}});
 }
 
-TEST_CASE("grade_returns_the_students_in_that_grade_in_alphabetical_order")
-{
+TEST_CASE("Students in multiple grades are added to the roster", "[75a51579-d1d7-407c-a2f8-2166e984e8ab]") {
+    grade_school::school school_;
+    school_.add("Chelsea", 3);
+    school_.add("Logan", 7);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{3, {"Chelsea"}}, {7, {"Logan"}}});
+}
+
+TEST_CASE("Cannot add same student to multiple grades in the roster", "[7df542f1-57ce-433c-b249-ff77028ec479]") {
+    grade_school::school school_;
+    school_.add("Aimee", 2);
+    school_.add("Aimee", 3);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Aimee"}}});
+}
+
+TEST_CASE("Student not added to multiple grades in the roster", "[c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 3);
+    school_.add("Paul", 3);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Blair", "James"}}, {3, {"Paul"}}});
+}
+
+TEST_CASE("Students are sorted by grades in the roster", "[d9af4f19-1ba1-48e7-94d0-dabda4e5aba6]") {
+    grade_school::school school_;
+    school_.add("Anna", 1);
+    school_.add("Jim", 3);
+    school_.add("Peter", 2);
+    REQUIRE(school_.roster() == map<int, vector<string>>{
+        {1, {"Anna"}},
+        {2, {"Peter"}},
+        {3, {"Jim"}}
+    });
+}
+
+TEST_CASE("Students are sorted by name in the roster", "[d9fb5bea-f5aa-4524-9d61-c158d8906807]") {
+    grade_school::school school_;
+    school_.add("Zoe", 2);
+    school_.add("Peter", 2);
+    school_.add("Alex", 2);
+    REQUIRE(school_.roster() == map<int, vector<string>>{{2, {"Alex", "Peter", "Zoe"}}});
+}
+
+TEST_CASE("Students are sorted by grades and then by name in the roster", "[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]") {
+    grade_school::school school_;
+    school_.add("Jim", 3);
+    school_.add("Peter", 2);
+    school_.add("Anna", 1);
+    school_.add("Barb", 1);
+    school_.add("Zoe", 2);
+    school_.add("Alex", 2);
+    school_.add("Charlie", 1);
+    REQUIRE(school_.roster() == map<int, vector<string>>{
+        {1, {"Anna", "Barb", "Charlie"}},
+        {2, {"Alex", "Peter", "Zoe"}},
+        {3, {"Jim"}}
+    });
+}
+
+TEST_CASE("Grade is empty if no students in the roster", "[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]") {
+    const grade_school::school school_;
+    REQUIRE(school_.grade(1).empty());
+}
+
+TEST_CASE("Grade is empty if no students in that grade", "[1e0cf06b-26e0-4526-af2d-a2e2df6a51d6]") {
+    grade_school::school school_;
+    school_.add("Peter", 2);
+    school_.add("Zoe", 2);
+    school_.add("Alex", 2);
+    school_.add("Jim", 3);
+    REQUIRE(school_.grade(1).empty());
+}
+
+TEST_CASE("Student not added to same grade more than once", "[2bfc697c-adf2-4b65-8d0f-c46e085f796e]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 2);
+    school_.add("Paul", 2);
+    REQUIRE(school_.grade(2) == vector<string>{"Blair", "James", "Paul"});
+}
+
+TEST_CASE("Student not added to multiple grades", "[66c8e141-68ab-4a04-a15a-c28bc07fe6b9]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 3);
+    school_.add("Paul", 3);
+    REQUIRE(school_.grade(2) == vector<string>{"Blair", "James"});
+}
+
+TEST_CASE("Student not added to other grade for multiple grades", "[c9c1fc2f-42e0-4d2c-b361-99271f03eda7]") {
+    grade_school::school school_;
+    school_.add("Blair", 2);
+    school_.add("James", 2);
+    school_.add("James", 3);
+    school_.add("Paul", 3);
+    REQUIRE(school_.grade(3) == vector<string>{"Paul"});
+}
+
+TEST_CASE("Students are sorted by name in a grade", "[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]") {
     grade_school::school school_;
     school_.add("Franklin", 5);
     school_.add("Bradley", 5);
     school_.add("Jeff", 1);
-
-    const auto actual = school_.grade(5);
-
-    const vector<string> expected{"Bradley", "Franklin"};
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("grade_returns_an_empty_array_if_there_are_no_students_in_that_grade")
-{
-    const grade_school::school school_{};
-    const auto actual = school_.grade(1);
-
-    REQUIRE(actual.empty());
-}
-
-TEST_CASE("the_student_names_in_each_grade_in_the_roster_are_sorted")
-{
-    grade_school::school school_;
-    school_.add("Jennifer", 4);
-    school_.add("Kareem", 6);
-    school_.add("Christopher", 4);
-    school_.add("Kyle", 3);
-
-    const auto actual = school_.roster();
-
-    const map<int, vector<string>> expected{
-            {3, {"Kyle"}},
-            {4, {"Christopher", "Jennifer"}},
-            {6, {"Kareem"}}
-        };
-    REQUIRE(expected == actual);
-}
-
-TEST_CASE("checking_a_grade_should_not_change_the_roster")
-{
-    const grade_school::school school_{};
-    school_.grade(1);
-    REQUIRE(school_.roster().empty());
+    REQUIRE(school_.grade(5) == vector<string>{"Bradley", "Franklin"});
 }
 
 #endif


### PR DESCRIPTION
This PR aims to update all tests in the `grade-school` exercise. The tests were created manually because the fact that some object-oriented adjustments were necessary made it impossible for the `exercise_creation_helper` to actually help. I'm hesitant the changes were done correctly because of my lack of experience with the platform, but I've tried to stick to the original test cases where possible and to use the same style with the missing test cases.

@vaeng let me know what you think.