### PR TITLE
Add /WX (warnings as errors) compile flag when compiling with MSVC.

### DIFF
--- a/exercises/concept/doctor-data/CMakeLists.txt
+++ b/exercises/concept/doctor-data/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/doctor-data/CMakeLists.txt
+++ b/exercises/concept/doctor-data/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/doctor-data/CMakeLists.txt
+++ b/exercises/concept/doctor-data/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/election-day/CMakeLists.txt
+++ b/exercises/concept/election-day/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/election-day/CMakeLists.txt
+++ b/exercises/concept/election-day/CMakeLists.txt
@@ -58,10 +58,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/election-day/CMakeLists.txt
+++ b/exercises/concept/election-day/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/ellens-alien-game/CMakeLists.txt
+++ b/exercises/concept/ellens-alien-game/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/ellens-alien-game/CMakeLists.txt
+++ b/exercises/concept/ellens-alien-game/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/ellens-alien-game/CMakeLists.txt
+++ b/exercises/concept/ellens-alien-game/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/freelancer-rates/CMakeLists.txt
+++ b/exercises/concept/freelancer-rates/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/freelancer-rates/CMakeLists.txt
+++ b/exercises/concept/freelancer-rates/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/freelancer-rates/CMakeLists.txt
+++ b/exercises/concept/freelancer-rates/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/interest-is-interesting/CMakeLists.txt
+++ b/exercises/concept/interest-is-interesting/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/interest-is-interesting/CMakeLists.txt
+++ b/exercises/concept/interest-is-interesting/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/interest-is-interesting/CMakeLists.txt
+++ b/exercises/concept/interest-is-interesting/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna-master/CMakeLists.txt
+++ b/exercises/concept/lasagna-master/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna-master/CMakeLists.txt
+++ b/exercises/concept/lasagna-master/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna-master/CMakeLists.txt
+++ b/exercises/concept/lasagna-master/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna/CMakeLists.txt
+++ b/exercises/concept/lasagna/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna/CMakeLists.txt
+++ b/exercises/concept/lasagna/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/lasagna/CMakeLists.txt
+++ b/exercises/concept/lasagna/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/last-will/CMakeLists.txt
+++ b/exercises/concept/last-will/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/last-will/CMakeLists.txt
+++ b/exercises/concept/last-will/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/last-will/CMakeLists.txt
+++ b/exercises/concept/last-will/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/log-levels/CMakeLists.txt
+++ b/exercises/concept/log-levels/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/log-levels/CMakeLists.txt
+++ b/exercises/concept/log-levels/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/log-levels/CMakeLists.txt
+++ b/exercises/concept/log-levels/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/making-the-grade/CMakeLists.txt
+++ b/exercises/concept/making-the-grade/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/making-the-grade/CMakeLists.txt
+++ b/exercises/concept/making-the-grade/CMakeLists.txt
@@ -58,10 +58,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/making-the-grade/CMakeLists.txt
+++ b/exercises/concept/making-the-grade/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/pacman-rules/CMakeLists.txt
+++ b/exercises/concept/pacman-rules/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/pacman-rules/CMakeLists.txt
+++ b/exercises/concept/pacman-rules/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/pacman-rules/CMakeLists.txt
+++ b/exercises/concept/pacman-rules/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/troll-the-trolls/CMakeLists.txt
+++ b/exercises/concept/troll-the-trolls/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/troll-the-trolls/CMakeLists.txt
+++ b/exercises/concept/troll-the-trolls/CMakeLists.txt
@@ -57,10 +57,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/troll-the-trolls/CMakeLists.txt
+++ b/exercises/concept/troll-the-trolls/CMakeLists.txt
@@ -59,7 +59,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/vehicle-purchase/CMakeLists.txt
+++ b/exercises/concept/vehicle-purchase/CMakeLists.txt
@@ -62,7 +62,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/vehicle-purchase/CMakeLists.txt
+++ b/exercises/concept/vehicle-purchase/CMakeLists.txt
@@ -60,10 +60,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/concept/vehicle-purchase/CMakeLists.txt
+++ b/exercises/concept/vehicle-purchase/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/acronym/CMakeLists.txt
+++ b/exercises/practice/acronym/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/all-your-base/CMakeLists.txt
+++ b/exercises/practice/all-your-base/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/all-your-base/CMakeLists.txt
+++ b/exercises/practice/all-your-base/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/all-your-base/CMakeLists.txt
+++ b/exercises/practice/all-your-base/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/allergies/CMakeLists.txt
+++ b/exercises/practice/allergies/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/anagram/CMakeLists.txt
+++ b/exercises/practice/anagram/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/anagram/CMakeLists.txt
+++ b/exercises/practice/anagram/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/anagram/CMakeLists.txt
+++ b/exercises/practice/anagram/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/armstrong-numbers/CMakeLists.txt
+++ b/exercises/practice/armstrong-numbers/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/atbash-cipher/CMakeLists.txt
+++ b/exercises/practice/atbash-cipher/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/atbash-cipher/CMakeLists.txt
+++ b/exercises/practice/atbash-cipher/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/atbash-cipher/CMakeLists.txt
+++ b/exercises/practice/atbash-cipher/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bank-account/CMakeLists.txt
+++ b/exercises/practice/bank-account/CMakeLists.txt
@@ -61,7 +61,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bank-account/CMakeLists.txt
+++ b/exercises/practice/bank-account/CMakeLists.txt
@@ -59,10 +59,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bank-account/CMakeLists.txt
+++ b/exercises/practice/bank-account/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/beer-song/CMakeLists.txt
+++ b/exercises/practice/beer-song/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/beer-song/CMakeLists.txt
+++ b/exercises/practice/beer-song/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/beer-song/CMakeLists.txt
+++ b/exercises/practice/beer-song/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search-tree/CMakeLists.txt
+++ b/exercises/practice/binary-search-tree/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search-tree/CMakeLists.txt
+++ b/exercises/practice/binary-search-tree/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search-tree/CMakeLists.txt
+++ b/exercises/practice/binary-search-tree/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search/CMakeLists.txt
+++ b/exercises/practice/binary-search/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search/CMakeLists.txt
+++ b/exercises/practice/binary-search/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary-search/CMakeLists.txt
+++ b/exercises/practice/binary-search/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary/CMakeLists.txt
+++ b/exercises/practice/binary/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary/CMakeLists.txt
+++ b/exercises/practice/binary/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/binary/CMakeLists.txt
+++ b/exercises/practice/binary/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/bob/CMakeLists.txt
+++ b/exercises/practice/bob/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/circular-buffer/CMakeLists.txt
+++ b/exercises/practice/circular-buffer/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/circular-buffer/CMakeLists.txt
+++ b/exercises/practice/circular-buffer/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/circular-buffer/CMakeLists.txt
+++ b/exercises/practice/circular-buffer/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/clock/CMakeLists.txt
+++ b/exercises/practice/clock/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/clock/CMakeLists.txt
+++ b/exercises/practice/clock/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/clock/CMakeLists.txt
+++ b/exercises/practice/clock/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/collatz-conjecture/CMakeLists.txt
+++ b/exercises/practice/collatz-conjecture/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/complex-numbers/CMakeLists.txt
+++ b/exercises/practice/complex-numbers/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/complex-numbers/CMakeLists.txt
+++ b/exercises/practice/complex-numbers/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/complex-numbers/CMakeLists.txt
+++ b/exercises/practice/complex-numbers/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/crypto-square/CMakeLists.txt
+++ b/exercises/practice/crypto-square/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/crypto-square/CMakeLists.txt
+++ b/exercises/practice/crypto-square/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/crypto-square/CMakeLists.txt
+++ b/exercises/practice/crypto-square/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/darts/CMakeLists.txt
+++ b/exercises/practice/darts/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/darts/CMakeLists.txt
+++ b/exercises/practice/darts/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/darts/CMakeLists.txt
+++ b/exercises/practice/darts/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/darts/darts_test.cpp
+++ b/exercises/practice/darts/darts_test.cpp
@@ -34,41 +34,41 @@ TEST_CASE("exactly_on_centre")
 
 TEST_CASE("near_the_centre")
 {
-    REQUIRE(darts::score(-0.1,-0.1) == 10);
+    REQUIRE(darts::score(-0.1f,-0.1f) == 10);
 }
 
 TEST_CASE("just_within_the_inner_circle")
 {
-    REQUIRE(darts::score(0.7,0.7) == 10);
+    REQUIRE(darts::score(0.7f,0.7f) == 10);
 }
 
 TEST_CASE("just_outside_the_inner_circle")
 {
-    REQUIRE(darts::score(0.8,-0.8) == 5);
+    REQUIRE(darts::score(0.8f,-0.8f) == 5);
 }
 
 TEST_CASE("just_within_the_middle_circle")
 {
-    REQUIRE(darts::score(-3.5,3.5) == 5);
+    REQUIRE(darts::score(-3.5f,3.5f) == 5);
 }
 
 TEST_CASE("just_outside_the_middle_circle")
 {
-    REQUIRE(darts::score(-3.6,-3.6) == 1);
+    REQUIRE(darts::score(-3.6f,-3.6f) == 1);
 }
 
 TEST_CASE("just_within_the_outer_circle")
 {
-    REQUIRE(darts::score(-7.0,7.0) == 1);
+    REQUIRE(darts::score(-7.0f,7.0f) == 1);
 }
 
 TEST_CASE("just_outside_the_outer_circle")
 {
-    REQUIRE(darts::score(7.1,-7.1) == 0);
+    REQUIRE(darts::score(7.1f,-7.1f) == 0);
 }
 
 TEST_CASE("asymmetric_position_between_the_inner_and_middle_circles")
 {
-    REQUIRE(darts::score(0.5,-4) == 5);
+    REQUIRE(darts::score(0.5f,-4) == 5);
 }
 #endif

--- a/exercises/practice/diamond/CMakeLists.txt
+++ b/exercises/practice/diamond/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/diamond/CMakeLists.txt
+++ b/exercises/practice/diamond/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/diamond/CMakeLists.txt
+++ b/exercises/practice/diamond/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/difference-of-squares/CMakeLists.txt
+++ b/exercises/practice/difference-of-squares/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/dnd-character/CMakeLists.txt
+++ b/exercises/practice/dnd-character/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/dnd-character/CMakeLists.txt
+++ b/exercises/practice/dnd-character/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/dnd-character/CMakeLists.txt
+++ b/exercises/practice/dnd-character/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/eliuds-eggs/CMakeLists.txt
+++ b/exercises/practice/eliuds-eggs/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/eliuds-eggs/CMakeLists.txt
+++ b/exercises/practice/eliuds-eggs/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/eliuds-eggs/CMakeLists.txt
+++ b/exercises/practice/eliuds-eggs/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/etl/CMakeLists.txt
+++ b/exercises/practice/etl/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/etl/CMakeLists.txt
+++ b/exercises/practice/etl/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/etl/CMakeLists.txt
+++ b/exercises/practice/etl/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/food-chain/CMakeLists.txt
+++ b/exercises/practice/food-chain/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/food-chain/CMakeLists.txt
+++ b/exercises/practice/food-chain/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/food-chain/CMakeLists.txt
+++ b/exercises/practice/food-chain/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -66,10 +66,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/gigasecond/CMakeLists.txt
+++ b/exercises/practice/gigasecond/CMakeLists.txt
@@ -68,7 +68,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grade-school/CMakeLists.txt
+++ b/exercises/practice/grade-school/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grade-school/CMakeLists.txt
+++ b/exercises/practice/grade-school/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grade-school/CMakeLists.txt
+++ b/exercises/practice/grade-school/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/grains/CMakeLists.txt
+++ b/exercises/practice/grains/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hamming/CMakeLists.txt
+++ b/exercises/practice/hamming/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hello-world/CMakeLists.txt
+++ b/exercises/practice/hello-world/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hexadecimal/CMakeLists.txt
+++ b/exercises/practice/hexadecimal/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hexadecimal/CMakeLists.txt
+++ b/exercises/practice/hexadecimal/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/hexadecimal/CMakeLists.txt
+++ b/exercises/practice/hexadecimal/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/high-scores/CMakeLists.txt
+++ b/exercises/practice/high-scores/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/high-scores/CMakeLists.txt
+++ b/exercises/practice/high-scores/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/high-scores/CMakeLists.txt
+++ b/exercises/practice/high-scores/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isbn-verifier/CMakeLists.txt
+++ b/exercises/practice/isbn-verifier/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isbn-verifier/CMakeLists.txt
+++ b/exercises/practice/isbn-verifier/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isbn-verifier/CMakeLists.txt
+++ b/exercises/practice/isbn-verifier/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/isogram/CMakeLists.txt
+++ b/exercises/practice/isogram/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/kindergarten-garden/CMakeLists.txt
+++ b/exercises/practice/kindergarten-garden/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/kindergarten-garden/CMakeLists.txt
+++ b/exercises/practice/kindergarten-garden/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/kindergarten-garden/CMakeLists.txt
+++ b/exercises/practice/kindergarten-garden/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/knapsack/CMakeLists.txt
+++ b/exercises/practice/knapsack/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/knapsack/CMakeLists.txt
+++ b/exercises/practice/knapsack/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/knapsack/CMakeLists.txt
+++ b/exercises/practice/knapsack/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/largest-series-product/CMakeLists.txt
+++ b/exercises/practice/largest-series-product/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/largest-series-product/CMakeLists.txt
+++ b/exercises/practice/largest-series-product/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/largest-series-product/CMakeLists.txt
+++ b/exercises/practice/largest-series-product/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/leap/CMakeLists.txt
+++ b/exercises/practice/leap/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/linked-list/CMakeLists.txt
+++ b/exercises/practice/linked-list/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/linked-list/CMakeLists.txt
+++ b/exercises/practice/linked-list/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/linked-list/CMakeLists.txt
+++ b/exercises/practice/linked-list/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/list-ops/CMakeLists.txt
+++ b/exercises/practice/list-ops/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/list-ops/CMakeLists.txt
+++ b/exercises/practice/list-ops/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/list-ops/CMakeLists.txt
+++ b/exercises/practice/list-ops/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/luhn/CMakeLists.txt
+++ b/exercises/practice/luhn/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/matching-brackets/CMakeLists.txt
+++ b/exercises/practice/matching-brackets/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/matching-brackets/CMakeLists.txt
+++ b/exercises/practice/matching-brackets/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/matching-brackets/CMakeLists.txt
+++ b/exercises/practice/matching-brackets/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -66,10 +66,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/meetup/CMakeLists.txt
+++ b/exercises/practice/meetup/CMakeLists.txt
@@ -68,7 +68,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/minesweeper/CMakeLists.txt
+++ b/exercises/practice/minesweeper/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/minesweeper/CMakeLists.txt
+++ b/exercises/practice/minesweeper/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/minesweeper/CMakeLists.txt
+++ b/exercises/practice/minesweeper/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nth-prime/CMakeLists.txt
+++ b/exercises/practice/nth-prime/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nucleotide-count/CMakeLists.txt
+++ b/exercises/practice/nucleotide-count/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nucleotide-count/CMakeLists.txt
+++ b/exercises/practice/nucleotide-count/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/nucleotide-count/CMakeLists.txt
+++ b/exercises/practice/nucleotide-count/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pangram/CMakeLists.txt
+++ b/exercises/practice/pangram/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/parallel-letter-frequency/CMakeLists.txt
+++ b/exercises/practice/parallel-letter-frequency/CMakeLists.txt
@@ -65,7 +65,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/parallel-letter-frequency/CMakeLists.txt
+++ b/exercises/practice/parallel-letter-frequency/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/parallel-letter-frequency/CMakeLists.txt
+++ b/exercises/practice/parallel-letter-frequency/CMakeLists.txt
@@ -63,10 +63,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pascals-triangle/CMakeLists.txt
+++ b/exercises/practice/pascals-triangle/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pascals-triangle/CMakeLists.txt
+++ b/exercises/practice/pascals-triangle/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pascals-triangle/CMakeLists.txt
+++ b/exercises/practice/pascals-triangle/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/perfect-numbers/CMakeLists.txt
+++ b/exercises/practice/perfect-numbers/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/perfect-numbers/CMakeLists.txt
+++ b/exercises/practice/perfect-numbers/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/perfect-numbers/CMakeLists.txt
+++ b/exercises/practice/perfect-numbers/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/phone-number/CMakeLists.txt
+++ b/exercises/practice/phone-number/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/phone-number/CMakeLists.txt
+++ b/exercises/practice/phone-number/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/phone-number/CMakeLists.txt
+++ b/exercises/practice/phone-number/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pig-latin/CMakeLists.txt
+++ b/exercises/practice/pig-latin/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pig-latin/CMakeLists.txt
+++ b/exercises/practice/pig-latin/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/pig-latin/CMakeLists.txt
+++ b/exercises/practice/pig-latin/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/prime-factors/CMakeLists.txt
+++ b/exercises/practice/prime-factors/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/prime-factors/CMakeLists.txt
+++ b/exercises/practice/prime-factors/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/prime-factors/CMakeLists.txt
+++ b/exercises/practice/prime-factors/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/protein-translation/CMakeLists.txt
+++ b/exercises/practice/protein-translation/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/queen-attack/CMakeLists.txt
+++ b/exercises/practice/queen-attack/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rail-fence-cipher/CMakeLists.txt
+++ b/exercises/practice/rail-fence-cipher/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rail-fence-cipher/CMakeLists.txt
+++ b/exercises/practice/rail-fence-cipher/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rail-fence-cipher/CMakeLists.txt
+++ b/exercises/practice/rail-fence-cipher/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/raindrops/CMakeLists.txt
+++ b/exercises/practice/raindrops/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color-duo/CMakeLists.txt
+++ b/exercises/practice/resistor-color-duo/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color-duo/CMakeLists.txt
+++ b/exercises/practice/resistor-color-duo/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color-duo/CMakeLists.txt
+++ b/exercises/practice/resistor-color-duo/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color/CMakeLists.txt
+++ b/exercises/practice/resistor-color/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color/CMakeLists.txt
+++ b/exercises/practice/resistor-color/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/resistor-color/CMakeLists.txt
+++ b/exercises/practice/resistor-color/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/reverse-string/CMakeLists.txt
+++ b/exercises/practice/reverse-string/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rna-transcription/CMakeLists.txt
+++ b/exercises/practice/rna-transcription/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-name/CMakeLists.txt
+++ b/exercises/practice/robot-name/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-name/CMakeLists.txt
+++ b/exercises/practice/robot-name/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-name/CMakeLists.txt
+++ b/exercises/practice/robot-name/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-simulator/CMakeLists.txt
+++ b/exercises/practice/robot-simulator/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-simulator/CMakeLists.txt
+++ b/exercises/practice/robot-simulator/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/robot-simulator/CMakeLists.txt
+++ b/exercises/practice/robot-simulator/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/roman-numerals/CMakeLists.txt
+++ b/exercises/practice/roman-numerals/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rotational-cipher/CMakeLists.txt
+++ b/exercises/practice/rotational-cipher/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rotational-cipher/CMakeLists.txt
+++ b/exercises/practice/rotational-cipher/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/rotational-cipher/CMakeLists.txt
+++ b/exercises/practice/rotational-cipher/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/run-length-encoding/CMakeLists.txt
+++ b/exercises/practice/run-length-encoding/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/run-length-encoding/CMakeLists.txt
+++ b/exercises/practice/run-length-encoding/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/run-length-encoding/CMakeLists.txt
+++ b/exercises/practice/run-length-encoding/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/say/CMakeLists.txt
+++ b/exercises/practice/say/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/say/CMakeLists.txt
+++ b/exercises/practice/say/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/say/CMakeLists.txt
+++ b/exercises/practice/say/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/scrabble-score/CMakeLists.txt
+++ b/exercises/practice/scrabble-score/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/scrabble-score/CMakeLists.txt
+++ b/exercises/practice/scrabble-score/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/scrabble-score/CMakeLists.txt
+++ b/exercises/practice/scrabble-score/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/secret-handshake/CMakeLists.txt
+++ b/exercises/practice/secret-handshake/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/secret-handshake/CMakeLists.txt
+++ b/exercises/practice/secret-handshake/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/secret-handshake/CMakeLists.txt
+++ b/exercises/practice/secret-handshake/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/series/CMakeLists.txt
+++ b/exercises/practice/series/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/series/CMakeLists.txt
+++ b/exercises/practice/series/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/series/CMakeLists.txt
+++ b/exercises/practice/series/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -61,6 +61,7 @@ if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
         COMPILE_FLAGS "/WX /W44244 /W44267")
+endif()
 
 # Run the tests on every build
 add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
-endif()
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 
 # Run the tests on every build
 add_custom_target(test_${exercise} ALL DEPENDS ${exercise} COMMAND ${exercise})

--- a/exercises/practice/sieve/CMakeLists.txt
+++ b/exercises/practice/sieve/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/simple-linked-list/CMakeLists.txt
+++ b/exercises/practice/simple-linked-list/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/simple-linked-list/CMakeLists.txt
+++ b/exercises/practice/simple-linked-list/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/simple-linked-list/CMakeLists.txt
+++ b/exercises/practice/simple-linked-list/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/space-age/CMakeLists.txt
+++ b/exercises/practice/space-age/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/spiral-matrix/CMakeLists.txt
+++ b/exercises/practice/spiral-matrix/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/spiral-matrix/CMakeLists.txt
+++ b/exercises/practice/spiral-matrix/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/spiral-matrix/CMakeLists.txt
+++ b/exercises/practice/spiral-matrix/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sublist/CMakeLists.txt
+++ b/exercises/practice/sublist/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sublist/CMakeLists.txt
+++ b/exercises/practice/sublist/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sublist/CMakeLists.txt
+++ b/exercises/practice/sublist/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/sum-of-multiples/CMakeLists.txt
+++ b/exercises/practice/sum-of-multiples/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/triangle/CMakeLists.txt
+++ b/exercises/practice/triangle/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/trinary/CMakeLists.txt
+++ b/exercises/practice/trinary/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/trinary/CMakeLists.txt
+++ b/exercises/practice/trinary/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/trinary/CMakeLists.txt
+++ b/exercises/practice/trinary/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-bucket/CMakeLists.txt
+++ b/exercises/practice/two-bucket/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-bucket/CMakeLists.txt
+++ b/exercises/practice/two-bucket/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-bucket/CMakeLists.txt
+++ b/exercises/practice/two-bucket/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/two-fer/CMakeLists.txt
+++ b/exercises/practice/two-fer/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/word-count/CMakeLists.txt
+++ b/exercises/practice/word-count/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/word-count/CMakeLists.txt
+++ b/exercises/practice/word-count/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/word-count/CMakeLists.txt
+++ b/exercises/practice/word-count/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/yacht/CMakeLists.txt
+++ b/exercises/practice/yacht/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/yacht/CMakeLists.txt
+++ b/exercises/practice/yacht/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/yacht/CMakeLists.txt
+++ b/exercises/practice/yacht/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/zebra-puzzle/CMakeLists.txt
+++ b/exercises/practice/zebra-puzzle/CMakeLists.txt
@@ -57,7 +57,8 @@ endif()
 # Tell MSVC not to warn us about unchecked iterators in debug builds
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
-        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS)
+        COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
+        COMPILE_FLAGS "/WX")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/zebra-puzzle/CMakeLists.txt
+++ b/exercises/practice/zebra-puzzle/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${EXERCISM_RUN_ALL_TESTS})
 endif()
 
 # Tell MSVC not to warn us about unchecked iterators in debug builds
+# Treat warnings as errors
+# Treat type conversion warnings C4244 and C4267 as level 4 warnings, i.e. ignore them in level 3
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX")
+        COMPILE_FLAGS "/WX /W44244 /W44267")
 endif()
 
 # Run the tests on every build

--- a/exercises/practice/zebra-puzzle/CMakeLists.txt
+++ b/exercises/practice/zebra-puzzle/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 if(${MSVC})
     set_target_properties(${exercise} PROPERTIES
         COMPILE_DEFINITIONS_DEBUG _SCL_SECURE_NO_WARNINGS
-        COMPILE_FLAGS "/WX /W44244 /W44267")
+        COMPILE_FLAGS "/WX /w44244 /w44267")
 endif()
 
 # Run the tests on every build


### PR DESCRIPTION
This PR fixes #922. When compiling with MSVC (Microsoft Visual C++) warnings are now treated as errors for all exercises.