### PR TITLE
fix: test case for interest_is_interesting_test.cpp

### DIFF
--- a/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
+++ b/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp
@@ -169,7 +169,7 @@ TEST_CASE("Years before desired balance for large start balance", "[task_4]") {
 TEST_CASE("Years before large difference between start and target balance", "[task_4]") {
     double balance{2345.67};
     double target_balance{12345.6789};
-    int want{85};
+    int want{104};
     REQUIRE(years_until_desired_balance(balance, target_balance) == want);
 }
 TEST_CASE("Balance is already above target", "[task_4]") {


### PR DESCRIPTION
The following test case contains an incorrect `want` value.

https://github.com/exercism/cpp/blob/acc32555eab077cf786f892b6ab27a22184d81c7/exercises/concept/interest-is-interesting/interest_is_interesting_test.cpp#L169-L174

Currently, the test case has the following parameters:

* $\texttt{balance} = 2345.67$
* $\texttt{target\\_balance} = 12345.6789$
* $\texttt{want} = 85$

However, the value of `want` is incorrect. Since $\texttt{balance} = 2345.67$, then, as given in the instructions, the interest rate is $\\% 1.621$. If we assume that $\texttt{want} = 85$ as given above, then the final balance after $\texttt{want}$ years is
```math
\begin{align}
\texttt{balance} \times \left(1 + \frac{\verb|interest_rate|}{100}\right)^\texttt{want} &= 2345.67 \times \left(1 + \frac{1.621}{100}\right)^{85} \\
&\approx \$ 9201.558
\end{align}
```
Similarly, the final balance after $\texttt{want} - 1$ years is approximately $\\$ 9054.78$. If the `want` value was correct, then the target balance would have been between the final balance after `want - 1` years and the final balance after `want` years. However, this is not the case.

This PR fixes the `want` value by setting it to $104$ years. We can see that this is indeed correct since
```math
\begin{align}
2345.67 \times \left(1 + \frac{1.621}{100}\right)^{103} &\approx \$ 12,290.334 \\
&< \verb|target_balance| = 12345.6789 \\
&< 2345.67 \times \left(1 + \frac{1.621}{100}\right)^{104} \approx \$ 12,489.561
\end{align}
```
