### PR TITLE
Update Documentation: Add MacOS with Make instructions for Exercism CLI

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -54,6 +54,7 @@ code using the appropriate command for your environment:
 * Linux with make: `make`
 * Windows with Visual Studio: Select Build / Build Solution from the menu.
 * MacOS with Xcode: Select Build from the toolbar
+* MacOS with "Unix Makefile": `make` _If using the exercism CLI app_
 
 Examples of running CMake for different environments are shown below.
 
@@ -105,4 +106,25 @@ Please download and install Xcode via the App Store or via [this link][web-xcode
 Errors similar to `The CXX compiler identification is unknown` will likely be resolved by following the [instructions to install GCC][cpp-installation-instructions] or by adding another target in Xcode as per the above paragraph.
 
 [web-xcode-download]: https://apps.apple.com/us/app/xcode/id497799835?mt=12
+[cpp-installation-instructions]: https://exercism.org/docs/tracks/cpp/installation
+
+### Mac OS with Make _when using the exercise CLI_
+#### This example will specifically assist those who want to use the Exercism CLI app for configuring, testing and submitting their CPP examples.
+
+The generator name for CMake is `Unix Makefiles`.
+Assuming the current exercise is `bob` and we're in the exercise folder:
+
+```sh
+$ touch bob.{h,cpp}
+$ cmake -G "Unix Makefiles" .
+$ exercism test
+```
+
+In this example we do not create empty files for the implementation before
+running CMake. This is because the Exercism CLI uses the `.exercism/metadata.json` file in the root directory to parse the test
+
+Simply type `exercism test` in the root directory to compile the tests. This should 
+generate compile time errors. Once the errors are fixed, `exercism test` will build and 
+run the tests using the exercism CLI.
+
 [cpp-installation-instructions]: https://exercism.org/docs/tracks/cpp/installation

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -111,7 +111,7 @@ Errors similar to `The CXX compiler identification is unknown` will likely be re
 ### MacOS with Make _when using the Exercism CLI_
 #### This example specifically assists those who want to use the Exercism CLI app for configuring, testing, and submitting their C++ exercises.
 
-The generator name for CMake is `Unix Makefiles`.  
+The generator name for CMake is `Unix Makefiles`.
 Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```sh

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -108,10 +108,10 @@ Errors similar to `The CXX compiler identification is unknown` will likely be re
 [web-xcode-download]: https://apps.apple.com/us/app/xcode/id497799835?mt=12
 [cpp-installation-instructions]: https://exercism.org/docs/tracks/cpp/installation
 
-### Mac OS with Make _when using the exercise CLI_
-#### This example will specifically assist those who want to use the Exercism CLI app for configuring, testing and submitting their CPP examples.
+### MacOS with Make _when using the Exercism CLI_
+#### This example specifically assists those who want to use the Exercism CLI app for configuring, testing, and submitting their C++ exercises.
 
-The generator name for CMake is `Unix Makefiles`.
+The generator name for CMake is `Unix Makefiles`.  
 Assuming the current exercise is `bob` and we're in the exercise folder:
 
 ```sh
@@ -120,11 +120,10 @@ $ cmake -G "Unix Makefiles" .
 $ exercism test
 ```
 
-In this example we do not create empty files for the implementation before
-running CMake. This is because the Exercism CLI uses the `.exercism/metadata.json` file in the root directory to parse the test
+In this example, we do create empty files for the implementation before running CMake, but we do **not** create an empty build directory.
+This is because the Exercism CLI uses the `.exercism/metadata.json` file in the root directory to parse the test cases.
 
-Simply type `exercism test` in the root directory to compile the tests. This should 
-generate compile time errors. Once the errors are fixed, `exercism test` will build and 
-run the tests using the exercism CLI.
+Simply type `exercism test` in the root directory to compile the tests. This should generate compile-time errors.
+Once the errors are fixed, running `exercism test` again will build and execute the tests using the Exercism CLI.
 
 [cpp-installation-instructions]: https://exercism.org/docs/tracks/cpp/installation


### PR DESCRIPTION
## Update Documentation: Add MacOS with Make instructions for Exercism CLI
This PR updates the documentation to improve the "MacOS with Make when using the Exercism CLI" section. The updated instructions clarify the process of configuring, testing, and submitting C++ exercises with the Exercism CLI on MacOS.

### Rationale:  
This update aligns the section with existing style and cadence in the documentation while providing additional clarity for users who may be unfamiliar with the nuances of the Exercism CLI setup. It aims to minimize confusion and ensure a smooth setup process on MacOS.

#### Impact:  
- Enhances the clarity of instructions for MacOS users.
- Provides explicit details to streamline the C++ exercise workflow with the Exercism CLI.

#### Testing:  
- Verified the commands and workflow on MacOS using `Unix Makefiles` with the Exercism CLI.
- Ensured documentation style and tone are consistent with existing content.  
