### PR TITLE
triangle: add smaller size equality test

### DIFF
--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -33,6 +33,9 @@ description = "isosceles triangle -> first two sides are equal"
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
 description = "isosceles triangle -> first and last sides are equal"
 
+[eca8ae18-e191-4795-836f-c6457e649d80]
+description = "isosceles triangle -> two smaller sides are equal"
+
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
 description = "isosceles triangle -> equilateral triangles are also isosceles"
 include = false

--- a/exercises/practice/triangle/triangle_test.cpp
+++ b/exercises/practice/triangle/triangle_test.cpp
@@ -71,6 +71,11 @@ TEST_CASE("isosceles triangle -> first and last sides are equal",
     REQUIRE(triangle::flavor::isosceles == triangle::kind(4, 3, 4));
 }
 
+TEST_CASE("isosceles triangle -> two smaller sides are equal",
+          "[eca8ae18 - e191 - 4795 - 836f - c6457e649d80]") {
+    REQUIRE(triangle::flavor::isosceles == triangle::kind(3, 4, 3));
+}
+
 TEST_CASE("isosceles triangle -> no sides are equal",
           "[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]") {
     REQUIRE_FALSE(triangle::flavor::isosceles == triangle::kind(2, 3, 4));


### PR DESCRIPTION
This tests the case where the sides are sorted. If the two smaller sides are equal, the code below will falsely classify the triangle as scalene rather than isosceles. The current tests do not test this case.

```cpp
flavor kind(float a, float b, float c) {
    std::array<float, 3> sides{a, b, c};
    std::sort(sides.begin(), sides.end()); // Sides sorting
    if (!is_positive(sides)) {
        throw std::domain_error("Sides must be positive");
    }
    if (!triangle_inequality(sides)) {
        throw std::domain_error("The triangle inequality is violated");
    }
    if (sides[0] == sides[2]) {
        return flavor::equilateral;
    } else if (sides[1] == sides[2]) { // This check is incorrect
        return flavor::isosceles;
    } else {
        return flavor::scalene;
    }
}
```