### PR TITLE
Remove unnecessary REQUIRE from test

### DIFF
--- a/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
+++ b/exercises/concept/ellens-alien-game/ellens_alien_game_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE("New alien does not share old aliens position", "[task_1]") {
 
 TEST_CASE("Alien is always hit", "[task_2]") {
     Alien alien{6, 7};
-    REQUIRE(alien.hit());
+    alien.hit();
 }
 
 TEST_CASE(
@@ -50,7 +50,7 @@ TEST_CASE(
 
 TEST_CASE("Alien Teleports reports succesful", "[task_4]") {
     Alien alien{22, 1};
-    REQUIRE(alien.teleport(99, 8));
+    alien.teleport(99, 8);
 }
 
 TEST_CASE("Alien Teleports where it should", "[task_4]") {


### PR DESCRIPTION
Hello, I think we have two uses of `REQUIRE` where it's not necessary due to functions that can not be evaluated by it.