### PR TITLE
tests: update crypto-square exercise (#775)

### DIFF
--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -32,3 +32,8 @@ description = "8 character plaintext results in 3 chunks, the last one with a tr
 
 [fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
 description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
+include = false
+
+[33fd914e-fa44-445b-8f38-ff8fbc9fe6e6]
+description = "54 character plaintext results in 8 chunks, the last two with trailing spaces"
+reimplements = "fbcb0c6d-4c39-4a31-83f6-c473baa6af80"

--- a/exercises/practice/crypto-square/crypto_square_test.cpp
+++ b/exercises/practice/crypto-square/crypto_square_test.cpp
@@ -46,9 +46,9 @@ TEST_CASE(
 
 TEST_CASE(
     // clang-format off
-    "54 character plaintext results in 7 chunks, the last two with trailing spaces",
+    "54 character plaintext results in 8 chunks, the last two with trailing spaces",
     // clang-format on
-    "[fbcb0c6d-4c39-4a31-83f6-c473baa6af80]") {
+    "[33fd914e-fa44-445b-8f38-ff8fbc9fe6e6]") {
     REQUIRE("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau " ==
             crypto_square::cipher("If man was meant to stay on the ground, god "
                                   "would have given us roots.")


### PR DESCRIPTION
## Description

This PR updates the crypto-square exercise test cases to sync with the latest problem-specifications, contributing to issue #775 for updating test cases across exercises.

### Changes Made

- **Replaced outdated test case**: Updated from "7 chunks" to "8 chunks" test case
- **Updated test UUID**: Changed from `fbcb0c6d-4c39-4a31-83f6-c473baa6af80` to `33fd914e-fa44-445b-8f38-ff8fbc9fe6e6`
- **Synced with problem-specifications**: Used configlet tool to ensure canonical data alignment
- **Test case description**: "54 character plaintext results in 8 chunks, the last two with trailing spaces"

### Files Modified

- `exercises/practice/crypto-square/.meta/tests.toml`
- `exercises/practice/crypto-square/crypto_square_test.cpp`

## Screenshots

### Before Changes
<img width="1506" alt="Screenshot 2025-07-07 at 12 36 54 PM" src="https://github.com/user-attachments/assets/372d0868-8a5a-43c0-8dc3-88d82abd6448" />

### After Changes  
<img width="1511" alt="Screenshot 2025-07-07 at 12 37 47 PM" src="https://github.com/user-attachments/assets/fdf96422-8b33-48cd-813e-2ea5c24dd070" />

### Test Execution
<!-- Screenshot showing all 8 test cases passing with detailed output -->
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/1d1b8d56-10b1-4491-8759-9e716e308c14" />


### Code Changes
![image](https://github.com/user-attachments/assets/b09857a9-f617-487e-a273-e0cb3a662d8a)

## Testing Instructions

To verify these changes work correctly:

```bash
# Navigate to the crypto-square exercise
cd exercises/practice/crypto-square

# Copy example implementation for testing
cp .meta/example.h crypto_square.h
cp .meta/example.cpp crypto_square.cpp

# Build with all tests enabled
cmake -DEXERCISM_RUN_ALL_TESTS=ON .
make

# Run tests with detailed output
./crypto-square -s

# Expected: All 8 test cases should pass, including the new "8 chunks" test

# Clean up
git restore crypto_square.h crypto_square.cpp
cd ../../..
```

### Expected Test Output
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/1d1b8d56-10b1-4491-8759-9e716e308c14" />

## Verification

✅ All 8 test cases pass  
✅ New test case properly validates 54-character plaintext  
✅ Configlet sync confirms no missing test cases for crypto-square  
✅ Exercise maintains backward compatibility  

### Configlet Verification
<img width="1511" alt="Screenshot 2025-07-07 at 12 37 47 PM" src="https://github.com/user-attachments/assets/fdf96422-8b33-48cd-813e-2ea5c24dd070" />

## Technical Details

- Used `configlet sync --tests include --update --yes -e crypto-square` to automatically sync test cases
- The old test case is marked as `include = false` in tests.toml
- New test case includes `reimplements` reference to show it replaces the old one
- Test logic and expected output remain unchanged, only UUID and description updated

### File Diffs
![image](https://github.com/user-attachments/assets/17978885-f3fd-4772-bc48-17862278a627)


## Progress on Issue #775

This completes crypto-square exercise updates. Remaining exercises with missing test cases:
- grade-school (16 missing)
- largest-series-product (2 missing) 
- protein-translation (4 missing)
- reverse-string (3 missing)

Fixes #775 (partial - crypto-square exercise)