### PR TITLE
Rectify tests.toml for reverse-string and clock

### DIFF
--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -55,6 +55,7 @@ description = "negative minutes roll over continuously"
 
 [1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
 description = "negative sixty minutes is previous hour"
+include = false
 
 [9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
 description = "negative hour and minutes both roll over"
@@ -157,3 +158,4 @@ description = "clocks with negative hours and minutes that wrap"
 
 [96969ca8-875a-48a1-86ae-257a528c44f5]
 description = "full clock and zeroed clock"
+include = false

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -19,3 +19,4 @@ description = "a palindrome"
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
+include = false


### PR DESCRIPTION
 Marks unimplemented tests as include = false for two exercises.

   - reverse-string: "an even-sized word" (b9e7dec1) not in test suite
   - clock: "negative sixty minutes is previous hour" (1cd19447) not in test suite
   - clock: "full clock and zeroed clock" (96969ca8) not in test suite